### PR TITLE
Add @Inherited and @Documented to the annotations.

### DIFF
--- a/src/main/java/org/springframework/shell/core/annotation/CliAvailabilityIndicator.java
+++ b/src/main/java/org/springframework/shell/core/annotation/CliAvailabilityIndicator.java
@@ -15,7 +15,9 @@
  */
 package org.springframework.shell.core.annotation;
 
+import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
@@ -42,6 +44,8 @@ import java.lang.annotation.Target;
  * @author Ben Alex
  * @since 1.0
  */
+@Inherited
+@Documented
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.METHOD)
 public @interface CliAvailabilityIndicator {

--- a/src/main/java/org/springframework/shell/core/annotation/CliCommand.java
+++ b/src/main/java/org/springframework/shell/core/annotation/CliCommand.java
@@ -15,7 +15,9 @@
  */
 package org.springframework.shell.core.annotation;
 
+import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
@@ -28,6 +30,8 @@ import java.lang.annotation.Target;
  * @since 1.0
  *
  */
+@Inherited
+@Documented
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.METHOD)
 public @interface CliCommand {

--- a/src/main/java/org/springframework/shell/core/annotation/CliOption.java
+++ b/src/main/java/org/springframework/shell/core/annotation/CliOption.java
@@ -15,7 +15,9 @@
  */
 package org.springframework.shell.core.annotation;
 
+import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
@@ -29,6 +31,8 @@ import org.springframework.shell.core.Converter;
  * @since 1.0
  *
  */
+@Inherited
+@Documented
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.PARAMETER)
 public @interface CliOption {


### PR DESCRIPTION
Adding @Inherited will permit command properties to be defined on an interface that extends CommandMarker, separating the declarative configuration and implementation, making it easier to read.
