### PR TITLE
SHL-115 make tests passing with non-US system locales

### DIFF
--- a/integration-test/src/test/java/org/springframework/shell/core/DateTest.java
+++ b/integration-test/src/test/java/org/springframework/shell/core/DateTest.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2011-2013 the original author or authors.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -23,6 +23,7 @@ import java.text.DateFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
+import java.util.Locale;
 
 import org.junit.Test;
 import org.slf4j.Logger;
@@ -31,11 +32,11 @@ import org.slf4j.LoggerFactory;
 
 /**
  * Date command test.
- * 
+ *
  * @author David Winterfeldt
  */
 public class DateTest extends AbstractShellIT {
-    
+
     final Logger logger = LoggerFactory.getLogger(getClass());
 
     private final static String PATTERN = "E, MMM d, yyyy h:mm:ss a zzz";
@@ -43,21 +44,21 @@ public class DateTest extends AbstractShellIT {
     @Test
     public void testShellStart() throws IOException, ParseException {
         Date now = new Date();
-        
+
         // wait one second to guarantee dates don't match
         try { Thread.sleep(1000); } catch (InterruptedException e) {}
-        
+
         String result = exec(DATE_COMMAND);
         result = result.substring(6);
-        
-        DateFormat formatter = new SimpleDateFormat(PATTERN);
-        
+
+        DateFormat formatter = new SimpleDateFormat(PATTERN, Locale.US);
+
         // date is parseable or exception would be thrown
         Date shellDate = formatter.parse(result);
-        
+
         logger.info("shell date='{}'", shellDate);
-        
+
         assertTrue("Shell date should be before date test was started.", now.before(shellDate));
     }
-    
+
 }

--- a/integration-test/src/test/java/org/springframework/shell/core/ScriptTest.java
+++ b/integration-test/src/test/java/org/springframework/shell/core/ScriptTest.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2011-2013 the original author or authors.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -23,6 +23,7 @@ import java.text.DateFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
+import java.util.Locale;
 
 import org.junit.Ignore;
 import org.junit.Test;
@@ -34,7 +35,7 @@ import org.slf4j.LoggerFactory;
  * Start shell jar test.
  */
 public class ScriptTest extends AbstractShellIT {
-    
+
     final Logger logger = LoggerFactory.getLogger(getClass());
 
     private final static String PATTERN = "E, MMM d, yyyy h:mm:ss a zzz";
@@ -43,21 +44,21 @@ public class ScriptTest extends AbstractShellIT {
     @Ignore
     public void testShellStart() throws IOException, ParseException {
         Date now = new Date();
-        
+
         // wait one second to guarantee dates don't match
         try { Thread.sleep(1000); } catch (InterruptedException e) {}
-        
+
         String result = exec(new String[] { SCRIPT_COMMAND, "../../integration-test/src/test/resources/date.script" });
         result = result.substring(6);
-        
-        DateFormat formatter = new SimpleDateFormat(PATTERN);
-        
+
+        DateFormat formatter = new SimpleDateFormat(PATTERN, Locale.US);
+
         // date is parseable or exception would be thrown
         Date shellDate = formatter.parse(result);
-        
+
         logger.info("shell date='{}' {}", shellDate);
-        
+
         assertTrue("Shell date should be before date test was started.", now.before(shellDate));
     }
-    
+
 }

--- a/shell/src/test/java/org/springframework/shell/AbstractShellTest.java
+++ b/shell/src/test/java/org/springframework/shell/AbstractShellTest.java
@@ -23,6 +23,7 @@ import static org.springframework.shell.core.CommandConstants.DATE_COMMAND;
 import java.text.DateFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
+import java.util.Locale;
 import java.util.UUID;
 
 import org.junit.After;
@@ -107,7 +108,7 @@ public abstract class AbstractShellTest {
         
         assertNotNull("Output for 'date' command shouldn't be null.", result);	    
 
-        DateFormat formatter = new SimpleDateFormat(PATTERN);
+        DateFormat formatter = new SimpleDateFormat(PATTERN, Locale.US);
         
         try {
             // date is parseable or exception would be thrown

--- a/shell/src/test/java/org/springframework/shell/commands/DateCommandTest.java
+++ b/shell/src/test/java/org/springframework/shell/commands/DateCommandTest.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2011-2013 the original author or authors.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -23,6 +23,7 @@ import java.text.DateFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
+import java.util.Locale;
 
 import org.junit.Test;
 import org.slf4j.Logger;
@@ -33,36 +34,36 @@ import org.springframework.shell.CommandResult;
 
 /**
  * Date command test.
- * 
+ *
  * @author David Winterfeldt
  */
 public class DateCommandTest extends AbstractDefaultShellTest {
-    
+
     final Logger logger = LoggerFactory.getLogger(getClass());
 
     @Test
     public void testDateCommand() throws ParseException {
         Date now = new Date();
-        
+
         // wait one second to guarantee dates don't match
         try { Thread.sleep(1000); } catch (InterruptedException e) {}
-        
+
         CommandResult cr = shell.exec(DATE_COMMAND);
-        
+
         String result = (String) cr.getCommandOutput().get(DATE_COMMAND);
 
         assertNotNull("Output for 'date' command shouldn't be null.", result);
-        
-        DateFormat formatter = new SimpleDateFormat(PATTERN);
-        
+
+        DateFormat formatter = new SimpleDateFormat(PATTERN, Locale.US);
+
         // date is parseable or exception would be thrown
         Date shellDate = formatter.parse(result);
-        
+
         logger.info("shell date='{}'", shellDate);
-        
+
         assertTrue("Shell date should be before date test was started.", now.before(shellDate));
-        
+
         verifySuccess(cr);
     }
-    
+
 }


### PR DESCRIPTION
SHL-115 force unit tests to use Locale.US locales.
