### PR TITLE
SHL-74: Upgrade to JLine 2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,7 +31,8 @@ dependencies {
     compile "org.springframework:spring-core:$springVersion"
     compile "org.springframework:spring-context-support:$springVersion"
     compile "commons-io:commons-io:$commonsioVersion"
-    compile "net.sourceforge.jline:jline:$jlineVersion"
+    //compile "net.sourceforge.jline:jline:$jlineVersion"
+    compile "jline:jline:2.11"
     compile "org.fusesource.jansi:jansi:$jansiVersion"
     compile "cglib:cglib:$cglibVersion"
 

--- a/src/main/java/org/springframework/shell/commands/ConsoleCommands.java
+++ b/src/main/java/org/springframework/shell/commands/ConsoleCommands.java
@@ -15,8 +15,9 @@
  */
 package org.springframework.shell.commands;
 
-import jline.ANSIBuffer;
+import static org.fusesource.jansi.Ansi.ansi;
 
+import org.fusesource.jansi.AnsiConsole;
 import org.springframework.shell.core.CommandMarker;
 import org.springframework.shell.core.annotation.CliCommand;
 import org.springframework.stereotype.Component;
@@ -25,15 +26,14 @@ import org.springframework.stereotype.Component;
  * Commands related to the manipulation of the jline console
  * 
  * @author Mark Pollack
- *
+ * 
  */
 @Component
-public class ConsoleCommands implements CommandMarker { 
-	
-	@CliCommand(value = {"cls", "clear"}, help = "Clears the console")
+public class ConsoleCommands implements CommandMarker {
+
+	@CliCommand(value = { "cls", "clear" }, help = "Clears the console")
 	public void clear() {
-		System.out.print(ANSIBuffer.ANSICodes.clrscr());
-		System.out.print(ANSIBuffer.ANSICodes.gotoxy(0, 0));
+		AnsiConsole.out().println(ansi().eraseScreen().cursor(0, 0));
 	}
 
 }

--- a/src/main/java/org/springframework/shell/core/JLineCompletorAdapter.java
+++ b/src/main/java/org/springframework/shell/core/JLineCompletorAdapter.java
@@ -18,17 +18,17 @@ package org.springframework.shell.core;
 import java.util.ArrayList;
 import java.util.List;
 
-import jline.Completor;
+import jline.console.completer.Completer;
 
 import org.springframework.util.Assert;
 
 /**
  * An implementation of JLine's {@link Completor} interface that delegates to a {@link Parser}.
- *
+ * 
  * @author Ben Alex
  * @since 1.0
  */
-public class JLineCompletorAdapter implements Completor {
+public class JLineCompletorAdapter implements Completer {
 
 	// Fields
 	private final Parser parser;
@@ -38,7 +38,7 @@ public class JLineCompletorAdapter implements Completor {
 		this.parser = parser;
 	}
 
-	@SuppressWarnings({"rawtypes","unchecked"})
+	@SuppressWarnings({ "rawtypes", "unchecked" })
 	public int complete(final String buffer, final int cursor, final List candidates) {
 		int result;
 		try {
@@ -46,9 +46,12 @@ public class JLineCompletorAdapter implements Completor {
 			List<Completion> completions = new ArrayList<Completion>();
 			result = parser.completeAdvanced(buffer, cursor, completions);
 			for (Completion completion : completions) {
-				candidates.add(new jline.Completion(completion.getValue(), completion.getFormattedValue(), completion.getHeading()));
+				// candidates.add(new jline.Completion(completion.getValue(), completion.getFormattedValue(), completion
+				// .getHeading()));
+				candidates.add(completion.getValue());
 			}
-		} finally {
+		}
+		finally {
 			JLineLogHandler.prohibitRedraw();
 		}
 		return result;


### PR DESCRIPTION
This has been done with no prior real knowledge of JLine, but seems to work pretty well, at least on the surface.

Definitely needs testing (esp. windows) and a bit of review.

One of the cool thing it brings is CTL-R reverse search.
One of the thing lost though, is headers in completion proposals, _i.e._

```
xd:>module info --name

Jobs
filehdfs      filejdbc      hdfsjdbc      hdfsmongodb   jdbchdfs

Processors
aggregator                bridge                    filter                    http-client               json-field-extractor      json-field-value-filter   json-to-tuple             object-to-json
script                    splitter                  transform

Sinks
aggregatecounter      avro                  counter               field-value-counter   file                  gauge                 gemfire-json-server   gemfire-server        hdfs
jdbc                  log                   mail                  mqtt                  rabbit                richgauge             router                splunk                tcp

Sources
file             gemfire          gemfire-cq       http             imap             jms              mail             mqtt             post             rabbit           reactor-syslog   syslog-tcp
syslog-udp       tail             tcp              tcp-client       time             trigger          twittersearch    twitterstream
```
