### PR TITLE
SHL-138: Allow singlequote delimited strings

### DIFF
--- a/src/main/java/org/springframework/shell/core/Tokenizer.java
+++ b/src/main/java/org/springframework/shell/core/Tokenizer.java
@@ -144,8 +144,8 @@ public class Tokenizer {
 	private String eatValue(boolean emptyKey) {
 		StringBuilder sb = new StringBuilder();
 		char endDelimiter = ' ';
-		if (buffer[pos] == '"') {
-			endDelimiter = '"';
+		if (buffer[pos] == '"' || buffer[pos] == '\'') {
+			endDelimiter = buffer[pos];
 			pos++;
 		}
 		// So that it can be retrieved later (if this is actually the last value)
@@ -176,9 +176,9 @@ public class Tokenizer {
 
 		// When here, we either ran out of input, or encountered our delim, or both
 		// Fail, unless we allow an unfinished quoted string to be reported
-		if (endDelimiter == '"' && // we're using quotes
+		if (endDelimiter != ' ' && // we're using quotes
 				pos == buffer.length && // we ran of input
-				(buffer[pos - 1] != '"' || // quotes are not properly closed
+				(buffer[pos - 1] != endDelimiter || // quotes are not properly closed
 				sb.length() == 0)) { // BUT it's ok if consumed nothing (pos-1 is *opening* quote then)
 			if (allowUnbalancedLastQuotedValue) {
 				openingQuotesHaveNotBeenClosed = true;

--- a/src/test/java/org/springframework/shell/core/TokenizerTests.java
+++ b/src/test/java/org/springframework/shell/core/TokenizerTests.java
@@ -24,6 +24,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -195,6 +196,22 @@ public class TokenizerTests {
 		expected.put("recursive", "--wizz");
 		expected.put("", "blow");
 		assertEquals(expected, result);
+
+	}
+
+	@Test
+	public void testSingleAndDoubleQuotingBehavior() {
+		Map<String, String> result = tokenize("--foo 'i have a double \" in me'");
+		assertEquals(Collections.singletonMap("foo", "i have a double \" in me"), result);
+
+		result = tokenize("--foo \"i have a double \\\" in me\"");
+		assertEquals(Collections.singletonMap("foo", "i have a double \" in me"), result);
+
+		result = tokenize("--foo \"i have a single ' in me\"");
+		assertEquals(Collections.singletonMap("foo", "i have a single ' in me"), result);
+
+		result = tokenize("--foo 'i have a single \\' in me'");
+		assertEquals(Collections.singletonMap("foo", "i have a single ' in me"), result);
 
 	}
 


### PR DESCRIPTION
This will be useful for eg JSON submission:

```
http post --data '{ "hello":    "i am valid json with spaces yet not backslashes" }'
```
