### PR TITLE
SHL-136: Report syntax error location to the user

### DIFF
--- a/src/main/java/org/springframework/shell/core/TokenizingException.java
+++ b/src/main/java/org/springframework/shell/core/TokenizingException.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.shell.core;
+
+@SuppressWarnings("serial")
+public class TokenizingException extends RuntimeException {
+
+	private final int offendingOffset;
+
+	private final char[] buffer;
+
+	private final String reason;
+
+	public TokenizingException(int offendingOffset, char[] buffer, String reason) {
+		super();
+		this.offendingOffset = offendingOffset;
+		this.buffer = buffer;
+		this.reason = reason;
+	}
+
+	public int getOffendingOffset() {
+		return offendingOffset;
+	}
+
+	public String getBuffer() {
+		return new String(buffer);
+	}
+
+	public String getReason() {
+		return reason;
+	}
+
+}


### PR DESCRIPTION
Adds a nice caret showing the offending position when something illegal is provided.
Some examples:

```
Welcome to Spring Shell. For assistance press or type "hint" then hit ENTER.
spring-shell>test foo --key bar coo
test foo --key bar coo
                   ^
You cannot specify 'coo' as another value for the default ('') option in a single command.
You already provided 'foo' earlier.
Did you forget to add quotes around the value of another option?

spring-shell>test --key foo bar --key coo
test --key foo bar --key coo
                   ^
You cannot specify 'coo' as another value for the '--key' option in a single command.
You already provided 'foo' earlier.

spring-shell>script --file "foo
script --file "foo
                  ^
Cannot have an unbalanced number of quotation marks

spring-shell>script --file "foo ain't \ugood"
script --file "foo ain't \ugood"
                         ^
Illegal unicode escape sequence: \ugood

```
