### PR TITLE
Make jline logging configurable

### DIFF
--- a/src/main/java/org/springframework/shell/core/JLineShell.java
+++ b/src/main/java/org/springframework/shell/core/JLineShell.java
@@ -85,6 +85,10 @@ public abstract class JLineShell extends AbstractShell implements Shell, Runnabl
 	private static final boolean JANSI_AVAILABLE = ClassUtils.isPresent(ANSI_CONSOLE_CLASSNAME,
 			JLineShell.class.getClassLoader());
 
+	private static final String CONSOLE_LOGGERS[] = {"org.springframework.shell.core.JLineShellComponent",
+							 "org.springframework.shell.core.AbstractShell",
+							 "org.springframework.shell.core.SimpleParser"};
+
 	private static final char ESCAPE = 27;
 
 	private static final String BEL = "\007";
@@ -115,12 +119,17 @@ public abstract class JLineShell extends AbstractShell implements Shell, Runnabl
 
 		setPromptPath(null);
 		
-		if(enableJLineLogging) {
-			JLineLogHandler handler = new JLineLogHandler(reader, this);
-			JLineLogHandler.prohibitRedraw(); // Affects this thread only
-			Logger mainLogger = Logger.getLogger("");
-			removeHandlers(mainLogger);
-			mainLogger.addHandler(handler);
+		JLineLogHandler handler = new JLineLogHandler(reader, this);
+		JLineLogHandler.prohibitRedraw(); // Affects this thread only
+		String consoleLoggers[] = {""};
+		if(!enableJLineLogging) {
+			consoleLoggers = CONSOLE_LOGGERS;
+		}
+
+		for(String loggerName : consoleLoggers) {
+			Logger logger = Logger.getLogger(loggerName);
+			removeHandlers(logger);
+			logger.addHandler(handler);
 		}
 
 		reader.addCompleter(new ParserCompleter(getParser()));

--- a/src/main/java/org/springframework/shell/core/JLineShell.java
+++ b/src/main/java/org/springframework/shell/core/JLineShell.java
@@ -76,6 +76,8 @@ import org.springframework.util.StringUtils;
  * @since 1.0
  */
 public abstract class JLineShell extends AbstractShell implements Shell, Runnable {
+	// Configurable parameters
+	public static boolean enableJLineLogging = Boolean.parseBoolean(System.getProperty("org.springframework.shell.core.JLineShell.enableJLineLogging", "true"));
 
 	// Constants
 	private static final String ANSI_CONSOLE_CLASSNAME = "org.fusesource.jansi.AnsiConsole";
@@ -112,12 +114,14 @@ public abstract class JLineShell extends AbstractShell implements Shell, Runnabl
 		reader = createConsoleReader();
 
 		setPromptPath(null);
-
-		JLineLogHandler handler = new JLineLogHandler(reader, this);
-		JLineLogHandler.prohibitRedraw(); // Affects this thread only
-		Logger mainLogger = Logger.getLogger("");
-		removeHandlers(mainLogger);
-		mainLogger.addHandler(handler);
+		
+		if(enableJLineLogging) {
+			JLineLogHandler handler = new JLineLogHandler(reader, this);
+			JLineLogHandler.prohibitRedraw(); // Affects this thread only
+			Logger mainLogger = Logger.getLogger("");
+			removeHandlers(mainLogger);
+			mainLogger.addHandler(handler);
+		}
 
 		reader.addCompleter(new ParserCompleter(getParser()));
 


### PR DESCRIPTION
Current implementation of JLineShell forces all logs being written to console, regardless of externally provided configuration. Since it is done in a separate thread, there is no way to revert settings cleaner.

I've added an configuration option that disables such behavior (probably may be done using cleaner fix)
