### PR TITLE
SHL-159

### DIFF
--- a/src/main/java/org/springframework/shell/Bootstrap.java
+++ b/src/main/java/org/springframework/shell/Bootstrap.java
@@ -16,7 +16,6 @@
 package org.springframework.shell;
 
 import java.io.IOException;
-import java.util.Arrays;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -105,6 +104,11 @@ public class Bootstrap {
 		
 		//try and see if there's additional arguments to be parser form the command line
 		//get the value from the XML bean definition file, bean name extraArguments
+		//The need to parse the arguments again arise since we need access to the extraArguments bean
+		//declared in the spring-shell-plugin.xml and for us to get access to it, we need to instantiate the spring context first. 
+		//However, the need to instantiate the CommandLine instance before creating the spring context.
+		//If we can find a way to somehow get the extraArguments first and the parse the command line, all this code would be cleaner
+		
 		String extraArguments = null;
 		try {
 			extraArguments = ctx.getBean("extraArguments", String.class);

--- a/src/main/java/org/springframework/shell/CommandLine.java
+++ b/src/main/java/org/springframework/shell/CommandLine.java
@@ -17,10 +17,7 @@ package org.springframework.shell;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
-import java.util.Set;
 
 
 /**
@@ -108,7 +105,6 @@ public class CommandLine {
 	public void removeFromShell (String arg, String val) {
 		List<String> newShellList = new ArrayList<String> ();
 		for (String shellCommand : shellExecuteList) {
-			
 			String cmd = shellCommand.replaceFirst(arg + " " + val, "").trim();
 			if (cmd.length()>0)
 				newShellList.add(cmd);


### PR DESCRIPTION
Supports adding additional custom arguments to the command line. Clients
should do this by defining a bean called "extraArguments" of type String
in the spring-shell-plugin.xml bean definition file.
