### PR TITLE
Add entries to .gitignore for idea generated files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ target/
 
 /bin/
 /*.log
+
+/.idea
+/*.iml


### PR DESCRIPTION
Adding entries to .gitignore for Intellij generated files may help developers who use Intellij while contributing spring-shell project.
