### PR TITLE
pass exception to logger

### DIFF
--- a/src/main/java/org/springframework/shell/core/SimpleExecutionStrategy.java
+++ b/src/main/java/org/springframework/shell/core/SimpleExecutionStrategy.java
@@ -15,6 +15,7 @@
  */
 package org.springframework.shell.core;
 
+import java.util.logging.Level
 import java.util.logging.Logger;
 
 import org.springframework.shell.event.ParseResult;
@@ -63,7 +64,7 @@ public class SimpleExecutionStrategy implements ExecutionStrategy {
 		try {
 			return ReflectionUtils.invokeMethod(parseResult.getMethod(), parseResult.getInstance(), parseResult.getArguments());
 		} catch (Throwable th) {
-			logger.severe("Command failed " + th);
+			logger.log(Level.SEVERE, th.getMessage(), th);
 			return handleThrowable(th);
 		}
 	}


### PR DESCRIPTION
Currently command exceptions are not logging a stacktrace, which makes debugging console commands a pain.