### PR TITLE
SHL-175 Multiple Output Formats for Commands

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ buildscript {
         maven { url 'http://repo.springsource.org/plugins-release' }
     }
     dependencies {
-        classpath 'org.springframework.build.gradle:docbook-reference-plugin:0.1.5'
+        classpath 'io.spring.gradle:docbook-reference-plugin:0.3.0'
         classpath 'org.springframework.build.gradle:spring-io-plugin:0.0.3.RELEASE'
     }
 }

--- a/src/main/java/org/springframework/shell/converters/CliPrinterShellConverter.java
+++ b/src/main/java/org/springframework/shell/converters/CliPrinterShellConverter.java
@@ -1,0 +1,74 @@
+/**
+ * 
+ */
+package org.springframework.shell.converters;
+
+import static org.springframework.util.Assert.notNull;
+
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.shell.core.Completion;
+import org.springframework.shell.core.Converter;
+import org.springframework.shell.core.MethodTarget;
+import org.springframework.shell.core.annotation.CliPrinter;
+import org.springframework.stereotype.Component;
+
+/**
+ * Spring Shell converter to convert command @{@link CliPrinter}-annotated arguments 
+ * to {@link CliPrinterTypeConverter}s
+ * 
+ * @author robin
+ */
+@Component
+public class CliPrinterShellConverter implements Converter<CliPrinterTypeConverter<?>> {
+	
+	public static final String CLI_OUTPUT_FLAG = "o";
+
+	// beans must be named "xyzOutputConverter" where "xyz" is the @CliPrinter command argument value
+	private static final String OUTPUT_CONVERTER_SUFFIX = "OutputConverter";
+	
+	/*
+	 * Spring will add all beans of type CliPrinterTypeConverter to this map
+	 * the key will be like "xyzOutputConverter", matching the bean name
+	 */
+	@Autowired(required=false)
+	private Map<String, CliPrinterTypeConverter<?>> converters;
+
+	/* (non-Javadoc)
+	 * @see org.springframework.shell.core.Converter#supports(java.lang.Class, java.lang.String)
+	 */
+	@Override
+	public boolean supports(Class<?> type, String optionContext) {
+		return CliPrinterTypeConverter.class.isAssignableFrom(type);
+	}
+
+	/* (non-Javadoc)
+	 * @see org.springframework.shell.core.Converter#convertFromText(java.lang.String, java.lang.Class, java.lang.String)
+	 */
+	@Override
+	public CliPrinterTypeConverter<?> convertFromText(String format, Class<?> targetType, String optionContext) {
+		notNull(format);
+		notNull(converters);
+		
+		String converterName = format.toLowerCase() + OUTPUT_CONVERTER_SUFFIX;
+		
+		if (converters.containsKey(converterName)) {
+			return converters.get(converterName);
+		}
+		
+		return null;
+	}
+
+	/* (non-Javadoc)
+	 * @see org.springframework.shell.core.Converter#getAllPossibleValues(java.util.List, java.lang.Class, java.lang.String, java.lang.String, org.springframework.shell.core.MethodTarget)
+	 */
+	@Override
+	public boolean getAllPossibleValues(List<Completion> completions,
+			Class<?> targetType, String existingData, String optionContext,
+			MethodTarget target) {
+		return false;
+	}
+
+}

--- a/src/main/java/org/springframework/shell/converters/CliPrinterTypeConverter.java
+++ b/src/main/java/org/springframework/shell/converters/CliPrinterTypeConverter.java
@@ -1,0 +1,15 @@
+/**
+ * 
+ */
+package org.springframework.shell.converters;
+
+import org.springframework.core.convert.converter.Converter;
+
+/**
+ * Spring Type Converter for Spring Shell command results to be converted to
+ *
+ * @author robin
+ */
+public interface CliPrinterTypeConverter<S> extends Converter<S, String> {
+
+}

--- a/src/main/java/org/springframework/shell/core/CliPrinterResult.java
+++ b/src/main/java/org/springframework/shell/core/CliPrinterResult.java
@@ -1,0 +1,79 @@
+/**
+ * 
+ */
+package org.springframework.shell.core;
+
+import static org.springframework.util.Assert.notNull;
+
+import java.io.Serializable;
+
+import org.springframework.shell.converters.CliPrinterTypeConverter;
+
+/**
+ * Decorator around command results that may type convert the result to a custom String format using the 
+ * provided {@link CliPrinterTypeConverter}
+ * 
+ * @author robin
+ */
+public class CliPrinterResult<T extends Object> implements Serializable {
+
+	private static final long serialVersionUID = 1L;
+
+	private final T result;
+	private final CliPrinterTypeConverter<T> printer;
+	
+	private String output;
+	
+	public CliPrinterResult(final T result) {
+		this(result, null);
+	}
+	
+	public CliPrinterResult(final T result, CliPrinterTypeConverter<T> printer) {
+		notNull(result, "A non-null result instance must be provided");
+		
+		this.result = result;
+		this.printer = printer;
+	}
+	
+	@Override
+	public String toString() {
+		if (getPrinter() != null) {
+			if (output == null) {
+				output = getPrinter().convert(result);
+			}
+			
+			return output;
+		}
+		
+		return result.toString();
+	}
+
+	/**
+	 * @return the output
+	 */
+	public String getOutput() {
+		return output;
+	}
+
+	/**
+	 * @param output the output to set
+	 */
+	public void setOutput(String output) {
+		this.output = output;
+	}
+
+	/**
+	 * @return the result
+	 */
+	public T getResult() {
+		return result;
+	}
+
+	/**
+	 * @return the printer
+	 */
+	public CliPrinterTypeConverter<T> getPrinter() {
+		return printer;
+	}
+	
+}

--- a/src/main/java/org/springframework/shell/core/SimpleExecutionStrategy.java
+++ b/src/main/java/org/springframework/shell/core/SimpleExecutionStrategy.java
@@ -50,8 +50,12 @@ public class SimpleExecutionStrategy implements ExecutionStrategy {
 					Object result = invoke(parseResult);
 					processor.afterReturningInvocation(parseResult, result);
 					
-					// return the CliPrinterResult decorator instance so that outputs can be customized
-					return new CliPrinterResult<Object>(result, (CliPrinterTypeConverter<Object>) parseResult.getPrinter());
+					if (parseResult.getPrinter() != null) {
+						// return the CliPrinterResult decorator instance so that outputs can be customized
+						return new CliPrinterResult<Object>(result, (CliPrinterTypeConverter<Object>) parseResult.getPrinter());
+					} else {
+						return result;
+					}
 				} catch (Throwable th) {
 					processor.afterThrowingInvocation(parseResult, th);
 					return handleThrowable(th);
@@ -60,8 +64,12 @@ public class SimpleExecutionStrategy implements ExecutionStrategy {
 			else {
 				Object result = invoke(parseResult);
 				
-				// return the CliPrinterResult decorator instance so that outputs can be customized
-				return new CliPrinterResult<Object>(result, (CliPrinterTypeConverter<Object>) parseResult.getPrinter());
+				if (parseResult.getPrinter() != null) {
+					// return the CliPrinterResult decorator instance so that outputs can be customized
+					return new CliPrinterResult<Object>(result, (CliPrinterTypeConverter<Object>) parseResult.getPrinter());
+				} else {
+					return result;
+				}
 			}
 		}
 	}

--- a/src/main/java/org/springframework/shell/core/annotation/CliPrinter.java
+++ b/src/main/java/org/springframework/shell/core/annotation/CliPrinter.java
@@ -1,0 +1,32 @@
+package org.springframework.shell.core.annotation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Annotation on a command method, that may be converter to a 
+ * Spring Shell converter, allowing it to use Spring Type Converters 
+ * for formatting the output of the command result instance
+ *
+ * @author robin
+ */
+@Inherited
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.PARAMETER)
+public @interface CliPrinter {
+	
+	public static final String NULL_VALUE = "__NULL__";
+
+	/**
+	 * @return the short name of the type converter
+	 */
+	String key() default "p";
+	
+	String defaultValue() default NULL_VALUE;
+
+}

--- a/src/main/java/org/springframework/shell/event/ParseResult.java
+++ b/src/main/java/org/springframework/shell/event/ParseResult.java
@@ -19,6 +19,7 @@ import java.lang.reflect.Method;
 import java.util.Arrays;
 
 import org.springframework.core.style.ToStringCreator;
+import org.springframework.shell.converters.CliPrinterTypeConverter;
 import org.springframework.shell.core.Converter;
 import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
@@ -39,15 +40,17 @@ public class ParseResult {
 	// Fields
 	private final Method method;
 	private final Object instance;
+	private final CliPrinterTypeConverter<?> printer; // may be null for default printing format
 	private final Object[] arguments; // May be null if no arguments needed
 
-	public ParseResult(final Method method, final Object instance, final Object[] arguments) {
+	public ParseResult(final Method method, final Object instance, final CliPrinterTypeConverter<?> printer, final Object[] arguments) {
 		Assert.notNull(method, "Method required");
 		Assert.notNull(instance, "Instance required");
 		int length = arguments == null ? 0 : arguments.length;
 		Assert.isTrue(method.getParameterTypes().length == length, "Required " + method.getParameterTypes().length + " arguments, but received " + length);
 		this.method = method;
 		this.instance = instance;
+		this.printer = printer;
 		this.arguments = arguments;
 	}
 
@@ -59,22 +62,37 @@ public class ParseResult {
 		return instance;
 	}
 
+	/**
+	 * @return the printerShortName
+	 */
+	public CliPrinterTypeConverter<?> getPrinter() {
+		return printer;
+	}
+
 	public Object[] getArguments() {
 		return arguments;
 	}
 
+	/* (non-Javadoc)
+	 * @see java.lang.Object#hashCode()
+	 */
 	@Override
 	public int hashCode() {
 		final int prime = 31;
 		int result = 1;
 		result = prime * result + Arrays.hashCode(arguments);
-		result = prime * result + ((instance == null) ? 0 : instance.hashCode());
+		result = prime * result
+				+ ((instance == null) ? 0 : instance.hashCode());
 		result = prime * result + ((method == null) ? 0 : method.hashCode());
+		result = prime * result + ((printer == null) ? 0 : printer.hashCode());
 		return result;
 	}
 
+	/* (non-Javadoc)
+	 * @see java.lang.Object#equals(java.lang.Object)
+	 */
 	@Override
-	public boolean equals(final Object obj) {
+	public boolean equals(Object obj) {
 		if (this == obj)
 			return true;
 		if (obj == null)
@@ -94,6 +112,11 @@ public class ParseResult {
 				return false;
 		} else if (!method.equals(other.method))
 			return false;
+		if (printer == null) {
+			if (other.printer != null)
+				return false;
+		} else if (!printer.equals(other.printer))
+			return false;
 		return true;
 	}
 
@@ -102,6 +125,7 @@ public class ParseResult {
 		ToStringCreator tsc = new ToStringCreator(this);
 		tsc.append("method", method);
 		tsc.append("instance", instance);
+		tsc.append("printer", printer);
 		tsc.append("arguments", StringUtils.arrayToCommaDelimitedString(arguments));
 		return tsc.toString();
 	}

--- a/src/test/java/org/springframework/shell/BootstrapTest.java
+++ b/src/test/java/org/springframework/shell/BootstrapTest.java
@@ -18,8 +18,8 @@ public class BootstrapTest {
 			JLineShellComponent shell = bootstrap.getJLineShellComponent();
 			
 			//This is a brittle assertion - as additiona 'test' commands are added to the suite, this number will increase.
-			Assert.assertEquals("Number of CommandMarkers is incorrect", 10, shell.getSimpleParser().getCommandMarkers().size());
-			Assert.assertEquals("Number of Converters is incorrect", 16, shell.getSimpleParser().getConverters().size());			
+			Assert.assertEquals("Number of CommandMarkers is incorrect", 11, shell.getSimpleParser().getCommandMarkers().size());
+			Assert.assertEquals("Number of Converters is incorrect", 17, shell.getSimpleParser().getConverters().size());			
 		} catch (RuntimeException t) {
 			throw t;
 		} finally {

--- a/src/test/java/org/springframework/shell/commands/PrinterCommandsTest.java
+++ b/src/test/java/org/springframework/shell/commands/PrinterCommandsTest.java
@@ -1,0 +1,32 @@
+/**
+ * 
+ */
+package org.springframework.shell.commands;
+
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.Test;
+import org.springframework.shell.core.CommandResult;
+
+/**
+ * Test demonstrating executing the same command but with different output formats (default and csv)
+ *
+ * @author robin
+ */
+public class PrinterCommandsTest extends AbstractShellIntegrationTest {
+	
+	@Test
+	public void customOutput_WithDefaultOutput_PrintsRegularOutput() throws Exception {
+		CommandResult cr = getShell().executeCommand("printer-test");
+		String result = cr.getResult().toString();
+		MatcherAssert.assertThat(result, Matchers.equalTo("TestPrinterResource [id=12345, name=TestName]"));
+	}
+	
+	@Test
+	public void customOutput_WithCsvChosen_PrintsCsvOutput() throws Exception {
+		CommandResult cr = getShell().executeCommand("printer-test --p csv");
+		String result = cr.getResult().toString();
+		MatcherAssert.assertThat(result, Matchers.equalTo("12345,TestName"));
+	}
+
+}

--- a/src/test/java/org/springframework/shell/commands/test/PrinterCommands.java
+++ b/src/test/java/org/springframework/shell/commands/test/PrinterCommands.java
@@ -1,0 +1,63 @@
+/**
+ * 
+ */
+package org.springframework.shell.commands.test;
+
+import org.springframework.shell.converters.CliPrinterTypeConverter;
+import org.springframework.shell.core.CommandMarker;
+import org.springframework.shell.core.annotation.CliCommand;
+import org.springframework.shell.core.annotation.CliPrinter;
+import org.springframework.stereotype.Component;
+
+/**
+ * Commands for customized outputs
+ * 
+ * @author robin
+ */
+@Component
+public class PrinterCommands implements CommandMarker {
+
+	@CliCommand(value={ "printer-test" })
+	public TestPrinterResource printerTest(@CliPrinter CliPrinterTypeConverter<TestPrinterResource> printer) {
+		return new TestPrinterResource("12345", "TestName");
+	};
+	
+	public class TestPrinterResource {
+		
+		private final String id;
+		private final String name;
+		
+		public TestPrinterResource() {
+			this(null, null);
+		}
+		
+		public TestPrinterResource(String id, String name) {
+			this.id = id;
+			this.name = name;			
+		}
+
+		/**
+		 * @return the id
+		 */
+		public String getId() {
+			return id;
+		}
+
+		/**
+		 * @return the name
+		 */
+		public String getName() {
+			return name;
+		}
+
+		/* (non-Javadoc)
+		 * @see java.lang.Object#toString()
+		 */
+		@Override
+		public String toString() {
+			return "TestPrinterResource [id=" + id + ", name=" + name + "]";
+		}
+		
+	}
+	
+}

--- a/src/test/java/org/springframework/shell/converters/CsvCliPrinterTypeConverter.java
+++ b/src/test/java/org/springframework/shell/converters/CsvCliPrinterTypeConverter.java
@@ -1,0 +1,22 @@
+/**
+ * 
+ */
+package org.springframework.shell.converters;
+
+import org.springframework.shell.commands.test.PrinterCommands;
+import org.springframework.shell.commands.test.PrinterCommands.TestPrinterResource;
+import org.springframework.shell.converters.CliPrinterTypeConverter;
+
+/**
+ * Spring Type Converter to convert a {@link TestPrinterResource} to a csv String 
+ * 
+ * @author robin
+ */
+public class CsvCliPrinterTypeConverter implements CliPrinterTypeConverter<PrinterCommands.TestPrinterResource> {
+
+	@Override
+	public String convert(TestPrinterResource source) {
+		return source.getId() + "," + source.getName();
+	}
+
+}

--- a/src/test/java/org/springframework/shell/core/SimpleExecutionStrategyTest.java
+++ b/src/test/java/org/springframework/shell/core/SimpleExecutionStrategyTest.java
@@ -63,9 +63,9 @@ public class SimpleExecutionStrategyTest {
 	public void testSimpleCommandProcessor() throws Exception {
 		Target target = new Target();
 		Method one = ReflectionUtils.findMethod(target.getClass(), "one");
-		ParseResult result = new ParseResult(one, target, null);
+		ParseResult result = new ParseResult(one, target, null, null);
 
-		assertEquals("one", execution.execute(result));
+		assertEquals("one", execution.execute(result).toString());
 		assertSame(result, target.before);
 		assertSame(result, target.after);
 	}
@@ -75,11 +75,11 @@ public class SimpleExecutionStrategyTest {
 		Target target = new Target();
 		Method one = ReflectionUtils.findMethod(target.getClass(), "one");
 		Method two = ReflectionUtils.findMethod(target.getClass(), "two");
-		ParseResult given = new ParseResult(one, target, null);
-		ParseResult redirect = new ParseResult(two, target, null);
+		ParseResult given = new ParseResult(one, target, null, null);
+		ParseResult redirect = new ParseResult(two, target, null, null);
 		target.beforeReturn = redirect;
 
-		assertEquals("two", execution.execute(given));
+		assertEquals("two", execution.execute(given).toString());
 		assertSame(given, target.before);
 		assertSame(redirect, target.after);
 	}

--- a/src/test/resources/META-INF/spring/spring-shell-plugin.xml
+++ b/src/test/resources/META-INF/spring/spring-shell-plugin.xml
@@ -6,5 +6,7 @@
 		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.1.xsd">
 
 	<context:component-scan base-package="org.springframework.shell.commands.test"/>
+	
+	<bean name="csvOutputConverter" class="org.springframework.shell.converters.CsvCliPrinterTypeConverter" />
 
 </beans>


### PR DESCRIPTION
Added support for commands supporting multiple output formats through a @CliPrinter-annotated parameter and Spring Type Conversion
- CliPrinter is the new annotation
- CliPrinterResult is the decorator object around command results to support customized output
- ParseResult now can store a CliPrinterTypeConverter
- CliPrinterShellConverter is a Spring Shell converter for @CliPrinter annotated parameters
- PrinterCommandsTest demonstrates usage
- SimpleParser and SimpleExecutionStrategy augmented to support printer logic
