### PR TITLE
SHL-183 Fix command prefix autocomplete bug

### DIFF
--- a/src/main/java/org/springframework/shell/converters/FileConverter.java
+++ b/src/main/java/org/springframework/shell/converters/FileConverter.java
@@ -70,7 +70,7 @@ public abstract class FileConverter implements Converter<File> {
 
 		for (File file : directory.listFiles()) {
 			if (adjustedUserInput == null || adjustedUserInput.length() == 0 ||
-				file.getName().toLowerCase().startsWith(adjustedUserInput.toLowerCase())) {
+				file.getName().startsWith(adjustedUserInput)) {
 
 				String completion = "";
 				if (directoryData.length() > 0)

--- a/src/test/java/org/springframework/shell/core/SimpleParserTests.java
+++ b/src/test/java/org/springframework/shell/core/SimpleParserTests.java
@@ -319,10 +319,8 @@ public class SimpleParserTests {
 		candidates.clear();
 		offset = parser.completeAdvanced(buffer, buffer.length(), candidates);
 
-		// TODO
-		// assertThat(candidates, hasItem(completionThat(is(equalTo("file --option")))));
-		// assertThat(candidates, not(hasItem(completionThat(startsWith("fileMore")))));
-
+		assertThat(candidates, hasItem(completionThat(is(equalTo("file --option ")))));
+		assertThat(candidates, not(hasItem(completionThat(startsWith("fileMore")))));
 	}
 
 	@Test
@@ -442,6 +440,15 @@ public class SimpleParserTests {
 		parser.add(new SamePrefixCommands());
 		ParseResult result = parser.parse("fo");
 		assertThat(result, nullValue(ParseResult.class));
+	}
+
+	@Test
+	public void testCommandPrefixCollisionFalseAmbiguity() {
+		parser.add(new SamePrefixCommands());
+		buffer = "foo ";
+		offset = parser.completeAdvanced(buffer, buffer.length(), candidates);
+
+		assertThat(candidates, not(hasItem(completionThat(startsWith("fooBar ")))));
 	}
 
 	@Test


### PR DESCRIPTION
Hi there,

I've fixed an issue which occurred when one command is a prefix of another.
e.g imagine if there are commands foo and fooBar
Formerly, if buffer was "foo ", or "foo [anything]" and tab is pressed, the buffer will be replaced with "foo" and autocomplete candidates "foo" and "fooBar" will be presented.

This has been fixed and a test added (and a relevant TODO dropped).

Thanks!