### PR TITLE
SHL-188: Add support for hidden CLI options

### DIFF
--- a/src/main/java/org/springframework/shell/core/SimpleParser.java
+++ b/src/main/java/org/springframework/shell/core/SimpleParser.java
@@ -1017,6 +1017,9 @@ public class SimpleParser implements Parser {
 						for (Annotation a : annotations) {
 							if (a instanceof CliOption) {
 								cliOption = (CliOption) a;
+								if (cliOption.hidden()) {
+									continue;
+								}
 
 								for (String key : cliOption.key()) {
 									if ("".equals(key)) {

--- a/src/main/java/org/springframework/shell/core/annotation/CliOption.java
+++ b/src/main/java/org/springframework/shell/core/annotation/CliOption.java
@@ -55,6 +55,11 @@ public @interface CliOption {
 	boolean mandatory() default false;
 
 	/**
+	 * @return true if this option is hidden from the user (defaults to false)
+	 */
+	boolean hidden() default false;
+	
+	/**
 	 * @return the default value to use if this option is unspecified by the user (defaults to __NULL__, which causes null to
 	 * be presented to any non-primitive parameter)
 	 */


### PR DESCRIPTION
This adds a new property `hidden` to `CliOption` annotation which will hide such options from `help`.