### PR TITLE
Moved sw.start() statement to beginning of run method.

### DIFF
--- a/src/main/java/org/springframework/shell/Bootstrap.java
+++ b/src/main/java/org/springframework/shell/Bootstrap.java
@@ -52,7 +52,6 @@ public class Bootstrap {
 	private GenericApplicationContext ctx;
 
 	public static void main(String[] args) throws IOException {
-		sw.start();
 		ExitShellRequest exitShellRequest;
 		try {
 			bootstrap = new Bootstrap(args);
@@ -144,7 +143,7 @@ public class Bootstrap {
 	}
 
 	public ExitShellRequest run() {
-
+		sw.start();
 		String[] commandsToExecuteAndThenQuit = commandLine.getShellCommandsToExecute();
 		// The shell is used
 		JLineShellComponent shell = ctx.getBean("shell", JLineShellComponent.class);


### PR DESCRIPTION
Now the stopwatch is started and stopped in the same method, so no matter how the Bootstrap instance is run, the stopwatch instance will start and stop properly, and without an exception.