### PR TITLE
Handle JLine's UserInterruptException

### DIFF
--- a/src/main/java/org/springframework/shell/Bootstrap.java
+++ b/src/main/java/org/springframework/shell/Bootstrap.java
@@ -91,6 +91,7 @@ public class Bootstrap {
 			scanner.scan("org.springframework.shell.commands", "org.springframework.shell.converters",
 					"org.springframework.shell.plugin.support");
 		}
+		scanner.scan("org.springframework.shell.config");
 		// user contributed commands
 		XmlBeanDefinitionReader reader = new XmlBeanDefinitionReader(ctx);
 		reader.loadBeanDefinitions(contextPath);
@@ -140,6 +141,8 @@ public class Bootstrap {
 
 	public ExitShellRequest run() {
 		StopWatch sw = new StopWatch("Spring Shell");
+		sw.start();
+
 		String[] commandsToExecuteAndThenQuit = commandLine.getShellCommandsToExecute();
 		// The shell is used
 		JLineShellComponent shell = ctx.getBean("shell", JLineShellComponent.class);

--- a/src/main/java/org/springframework/shell/config/ApplicationContextProvider.java
+++ b/src/main/java/org/springframework/shell/config/ApplicationContextProvider.java
@@ -1,0 +1,24 @@
+package org.springframework.shell.config;
+
+import org.springframework.beans.BeansException;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ApplicationContextAware;
+import org.springframework.stereotype.Component;
+
+/**
+ * @author nmeierling
+ */
+@Component
+public class ApplicationContextProvider implements ApplicationContextAware {
+
+    private static ApplicationContext applicationContext;
+
+    public static ApplicationContext getApplicationContext() {
+        return applicationContext;
+    }
+
+    @Override
+    public void setApplicationContext(ApplicationContext ctx) throws BeansException {
+        applicationContext = ctx;
+    }
+}

--- a/src/main/java/org/springframework/shell/config/JLineConfig.java
+++ b/src/main/java/org/springframework/shell/config/JLineConfig.java
@@ -1,0 +1,20 @@
+package org.springframework.shell.config;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.PropertySource;
+import org.springframework.core.env.Environment;
+
+/**
+ * @author nmeierling
+ */
+@Configuration
+@PropertySource("classpath:application.properties")
+public class JLineConfig {
+    @Autowired
+    Environment env;
+
+    public boolean isHandleUserInterrupt() {
+        return Boolean.parseBoolean(env.getProperty("jline.handleuserinterrupt"));
+    }
+}

--- a/src/main/java/org/springframework/shell/core/JLineShell.java
+++ b/src/main/java/org/springframework/shell/core/JLineShell.java
@@ -49,6 +49,8 @@ import org.fusesource.jansi.Ansi.Attribute;
 import org.fusesource.jansi.Ansi.Color;
 import org.fusesource.jansi.Ansi.Erase;
 import org.fusesource.jansi.AnsiConsole;
+import org.springframework.shell.config.ApplicationContextProvider;
+import org.springframework.shell.config.JLineConfig;
 import org.springframework.shell.event.ShellStatus;
 import org.springframework.shell.event.ShellStatus.Status;
 import org.springframework.shell.event.ShellStatusListener;
@@ -124,6 +126,11 @@ public abstract class JLineShell extends AbstractShell implements Shell, Runnabl
 		reader.setBellEnabled(true);
 		if (Boolean.getBoolean("jline.nobell")) {
 			reader.setBellEnabled(false);
+		}
+
+		final JLineConfig config = ApplicationContextProvider.getApplicationContext().getBean(JLineConfig.class);
+		if (config.isHandleUserInterrupt()){
+			reader.setHandleUserInterrupt(true);
 		}
 
 		// reader.setDebug(new PrintWriter(new FileWriter("writer.debug", true)));
@@ -539,6 +546,9 @@ public abstract class JLineShell extends AbstractShell implements Shell, Runnabl
 		}
 		catch (IOException ioe) {
 			throw new IllegalStateException("Shell line reading failure", ioe);
+		}
+		catch (UserInterruptException e){ // only thrown if jline.handleuserinterrupt=true
+			promptLoop();
 		}
 		setShellStatus(Status.SHUTTING_DOWN);
 	}

--- a/src/main/java/org/springframework/shell/core/JLineShell.java
+++ b/src/main/java/org/springframework/shell/core/JLineShell.java
@@ -40,6 +40,7 @@ import java.util.logging.Logger;
 
 import jline.WindowsTerminal;
 import jline.console.ConsoleReader;
+import jline.console.UserInterruptException;
 import jline.console.history.History;
 import jline.console.history.MemoryHistory;
 


### PR DESCRIPTION
You can now optionally disable quitting spring-shell by firing an UserInterruptException (eg. ctrl+c). This is useful in cases, where you mistyped a command and are used to clear the line with an Interrupt. 