### PR TITLE
SHL-146 Restore cursor position on flash

### DIFF
--- a/src/main/java/org/springframework/shell/core/JLineShell.java
+++ b/src/main/java/org/springframework/shell/core/JLineShell.java
@@ -500,7 +500,7 @@ public abstract class JLineShell extends AbstractShell implements Shell, Runnabl
 			ansi.a(ESCAPE + "8");
 		}
 		else {
-			ansi.reset();
+			ansi.restorCursorPosition();
 		}
 
 		try {


### PR DESCRIPTION
Fix for cursor reset instead of restore bug that was introduced in jline2 upgrade