### PR TITLE
add .gitattributes to force *.txt files to use eol=lf at checkout

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.txt text eol=lf


### PR DESCRIPTION
@ericbottard minor update to help users that checkout the project in Windows platforms - helps mainly with the tests in the spring-shell-standard-commands project