### PR TITLE
Fix documentation

### DIFF
--- a/spring-shell-docs/src/main/asciidoc/using-spring-shell.adoc
+++ b/spring-shell-docs/src/main/asciidoc/using-spring-shell.adoc
@@ -239,7 +239,7 @@ to specify the same parameter (so only one of them can be used). Here is an exam
 [source, java]
 ----
 	@ShellMethod("Describe a command.")
-	public String help(@ShellOption({"-C", "--command"} String command) {
+	public String execute(@ShellOption({"-C", "--command"}) String command) {
 		...
 	}
 ----
@@ -252,7 +252,7 @@ those parameters:
 [source, java]
 ----
 	@ShellMethod("Say hello.")
-	public String greet(@ShellOption(defaultValue="World"} String who) {
+	public String greet(@ShellOption(defaultValue="World") String who) {
 		return "Hello " + who;
 	}
 ----
@@ -587,8 +587,6 @@ The default value for the `@ShellMethodAvailability.value()` attribute is `"*"` 
 wildcard that matches all command names. It's thus easy to turn all commands of a single class on or off
 with a single availability method.
 ====
-
-
 
 [TIP]
 ====


### PR DESCRIPTION
 - Optional Parameters and Default Values. 
         Typo error in greet method signature who cause compile error
 - Customizing the Named Parameter Key(s). 
         help method is already registered in spring shell by default and cannot be reused