### PR TITLE
Add optional command grouping

### DIFF
--- a/spring-shell-standard-commands/src/test/java/org/springframework/shell/standard/commands/HelpTest.java
+++ b/spring-shell-standard-commands/src/test/java/org/springframework/shell/standard/commands/HelpTest.java
@@ -125,6 +125,12 @@ public class HelpTest {
 				methodTarget = MethodTarget.of("thirdCommand", commands(), "The last command.");
 				result.put("third-command", methodTarget);
 
+				methodTarget = MethodTarget.of("firstCommandInGroup", commands(), "The first command in a separate group.", "Example Group");
+				result.put("first-group-command", methodTarget);
+
+				methodTarget = MethodTarget.of("secondCommandInGroup", commands(), "The second command in a separate group.", "Example Group");
+				result.put("second-group-command", methodTarget);
+
 				return result;
 			};
 		}
@@ -166,6 +172,16 @@ public class HelpTest {
 
 		@ShellMethod
 		public void thirdCommand() {
+
+		}
+
+		@ShellMethod
+		public void firstCommandInGroup() {
+
+		}
+
+		@ShellMethod
+		public void secondCommandInGroup() {
 
 		}
 

--- a/spring-shell-standard-commands/src/test/java/org/springframework/shell/standard/commands/HelpTest.java
+++ b/spring-shell-standard-commands/src/test/java/org/springframework/shell/standard/commands/HelpTest.java
@@ -22,9 +22,12 @@ import java.io.InputStreamReader;
 import java.lang.reflect.Method;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 
 import org.assertj.core.api.Assertions;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestName;
@@ -57,6 +60,19 @@ import javax.validation.constraints.Max;
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration(classes = HelpTest.Config.class)
 public class HelpTest {
+
+	private static Locale previousLocale;
+
+	@BeforeClass
+	public static void setAssumedLocale() {
+		previousLocale = Locale.getDefault();
+		Locale.setDefault(Locale.ENGLISH);
+	}
+
+	@AfterClass
+	public static void restorePreviousLocale() {
+		Locale.setDefault(previousLocale);
+	}
 
 	@Autowired
 	private Help help;

--- a/spring-shell-standard-commands/src/test/resources/org/springframework/shell/standard/commands/HelpTest-testCommandList.txt
+++ b/spring-shell-standard-commands/src/test/resources/org/springframework/shell/standard/commands/HelpTest-testCommandList.txt
@@ -1,6 +1,11 @@
 AVAILABLE COMMANDS&
 &
+Default&
         1st-command, first-command: A rather extensive description of some command.&
         second-command, yet-another-command: The second command. This one is known under several aliases as well.&
         third-command: The last command.&
+&
+Example Group&
+        first-group-command: The first command in a separate group.&
+        second-group-command: The second command in a separate group.&
 &

--- a/spring-shell-standard/src/main/java/org/springframework/shell/standard/ShellMethod.java
+++ b/spring-shell-standard/src/main/java/org/springframework/shell/standard/ShellMethod.java
@@ -53,4 +53,11 @@ public @interface ShellMethod {
 	 */
 	String prefix() default "--";
 
+	/**
+	 * The command group which this command belongs to. The command group is used when printing a list of
+	 * commands to group related commands.
+	 * @return name of the command group
+	 */
+	String group() default "";
+
 }

--- a/spring-shell-standard/src/main/java/org/springframework/shell/standard/StandardMethodTargetRegistrar.java
+++ b/spring-shell-standard/src/main/java/org/springframework/shell/standard/StandardMethodTargetRegistrar.java
@@ -61,9 +61,10 @@ public class StandardMethodTargetRegistrar implements MethodTargetRegistrar {
 				if (keys.length == 0) {
 					keys = new String[] { Utils.unCamelify(method.getName()) };
 				}
+				String group = shellMapping.group();
 				for (String key : keys) {
 					Supplier<Availability> availabilityIndicator = findAvailabilityIndicator(keys, bean, method);
-					MethodTarget target = new MethodTarget(method, bean, shellMapping.value(), availabilityIndicator);
+					MethodTarget target = new MethodTarget(method, bean, shellMapping.value(), group, availabilityIndicator);
 					registry.register(key, target);
 					commands.put(key, target);
 				}


### PR DESCRIPTION
The output of `help` command is now grouped. Commands without group are in a group called "Default" on top.

Resolves #135