### PR TITLE
Fix method annotation in some reference documentation snippets

### DIFF
--- a/spring-shell-docs/src/main/asciidoc/using-spring-shell.adoc
+++ b/spring-shell-docs/src/main/asciidoc/using-spring-shell.adoc
@@ -647,10 +647,10 @@ Here is a short example:
 [source,java]
 ----
 public class UserCommands {
-    @ShellCommand(value = "This command ends up in the 'User Commands' group")
+    @ShellMethod(value = "This command ends up in the 'User Commands' group")
     public void foo() {}
 
-    @ShellCommand(value = "This command ends up in the 'Other Commands' group",
+    @ShellMethod(value = "This command ends up in the 'Other Commands' group",
     	group = "Other Commands")
     public void bar() {}
 }
@@ -803,7 +803,7 @@ to override the `clear` command:
 ----
 public class MyClear implements Clear.Command {
 
-    @ShellCommand("Clear the screen, only better.")
+    @ShellMethod("Clear the screen, only better.")
     public void clear() {
         // ...
     }


### PR DESCRIPTION
Somehow `@ShellCommand` found its way into the snippets. This commit
replaces it with the correct annotation `@ShellMethod`.

Keep up the good work!

PS: I stumbled upon this typo while writing "First hand experience migrating from Spring Shell 1.2 to 2.0" -  https://devops.datenkollektiv.de/migrating-from-spring-shell-12-to-20.html today.