### PR TITLE
Fix version of parent pom in spring-shell-samples

### DIFF
--- a/spring-shell-samples/pom.xml
+++ b/spring-shell-samples/pom.xml
@@ -9,7 +9,7 @@
 	<parent>
 		<groupId>org.springframework.shell</groupId>
 		<artifactId>spring-shell-parent</artifactId>
-		<version>2.0.0.BUILD-SNAPSHOT</version>
+		<version>2.0.1.BUILD-SNAPSHOT</version>
 	</parent>
 	
 	<description>Examples of using Spring Shell 2</description>


### PR DESCRIPTION
Travis rejected my pull request https://github.com/spring-projects/spring-shell/pull/197 due to a wrong version of the parent pom in spring-shell-samples. Since this seem unrelated I created another pull request.