### PR TITLE
try to avoid reflective access that make Java 9+ unhappy

### DIFF
--- a/spring-shell-jcommander-adapter/src/main/java/org/springframework/shell/jcommander/JCommanderParameterResolver.java
+++ b/spring-shell-jcommander-adapter/src/main/java/org/springframework/shell/jcommander/JCommanderParameterResolver.java
@@ -1,23 +1,33 @@
 /*
- * Copyright 2015 the original author or authors.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+	* Copyright 2015 the original author or authors.
+	*
+	* Licensed under the Apache License, Version 2.0 (the "License");
+	* you may not use this file except in compliance with the License.
+	* You may obtain a copy of the License at
+	*
+	*      http://www.apache.org/licenses/LICENSE-2.0
+	*
+	* Unless required by applicable law or agreed to in writing, software
+	* distributed under the License is distributed on an "AS IS" BASIS,
+	* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	* See the License for the specific language governing permissions and
+	* limitations under the License.
+	*/
 
 package org.springframework.shell.jcommander;
 
-import static org.springframework.shell.Utils.unCamelify;
+import com.beust.jcommander.*;
+import org.springframework.beans.BeanUtils;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.MethodParameter;
+import org.springframework.shell.*;
+import org.springframework.shell.ParameterDescription;
+import org.springframework.util.ReflectionUtils;
 
+import javax.validation.Validation;
+import javax.validation.Validator;
+import javax.validation.ValidatorFactory;
+import javax.validation.metadata.BeanDescriptor;
 import java.lang.annotation.Annotation;
 import java.util.Arrays;
 import java.util.Collection;
@@ -27,38 +37,18 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import org.springframework.beans.BeanUtils;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.core.MethodParameter;
-import org.springframework.shell.CompletionContext;
-import org.springframework.shell.CompletionProposal;
-import org.springframework.shell.ParameterDescription;
-import org.springframework.shell.ParameterResolver;
-import org.springframework.shell.ValueResult;
-import org.springframework.util.ReflectionUtils;
-
-import com.beust.jcommander.DynamicParameter;
-import com.beust.jcommander.JCommander;
-import com.beust.jcommander.Parameter;
-import com.beust.jcommander.ParameterException;
-import com.beust.jcommander.ParametersDelegate;
-
-import javax.validation.Validation;
-import javax.validation.Validator;
-import javax.validation.ValidatorFactory;
-import javax.validation.metadata.BeanDescriptor;
-import javax.validation.metadata.MethodDescriptor;
-import javax.validation.metadata.ParameterDescriptor;
+import static org.springframework.shell.Utils.unCamelify;
 
 /**
- * Provides integration with JCommander.
- *
- * @author Eric Bottard
- */
+	* Provides integration with JCommander.
+	*
+	* @author Eric Bottard
+	* @author Josh Long
+	*/
 public class JCommanderParameterResolver implements ParameterResolver {
 
 	private static final Collection<Class<? extends Annotation>> JCOMMANDER_ANNOTATIONS =
-			Arrays.asList(Parameter.class, DynamicParameter.class, ParametersDelegate.class);
+		Arrays.asList(Parameter.class, DynamicParameter.class, ParametersDelegate.class);
 
 	private Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
 
@@ -70,24 +60,29 @@ public class JCommanderParameterResolver implements ParameterResolver {
 	@Override
 	public boolean supports(MethodParameter parameter) {
 		AtomicBoolean isSupported = new AtomicBoolean(false);
-
 		Class<?> parameterType = parameter.getParameterType();
-		ReflectionUtils.doWithFields(parameterType, field -> {
-			ReflectionUtils.makeAccessible(field);
-			boolean hasAnnotation = Arrays.stream(field.getAnnotations())
-					.map(Annotation::annotationType)
-					.anyMatch(JCOMMANDER_ANNOTATIONS::contains);
-			isSupported.compareAndSet(false, hasAnnotation);
 
-		});
+		if (isLegalReflectiveAccess(parameterType)) {
+			ReflectionUtils.doWithFields(parameterType, field -> {
+				if (isLegalReflectiveAccess(field.getType())) {
+					ReflectionUtils.makeAccessible(field);
+					boolean hasAnnotation = Arrays.stream(field.getAnnotations())
+						.map(Annotation::annotationType)
+						.anyMatch(JCOMMANDER_ANNOTATIONS::contains);
+					isSupported.compareAndSet(false, hasAnnotation);
+				}
+			});
 
-		ReflectionUtils.doWithMethods(parameterType, method -> {
-			ReflectionUtils.makeAccessible(method);
-			boolean hasAnnotation = Arrays.stream(method.getAnnotations())
-					.map(Annotation::annotationType)
-					.anyMatch(Parameter.class::equals);
-			isSupported.compareAndSet(false, hasAnnotation);
-		});
+			ReflectionUtils.doWithMethods(parameterType, method -> {
+				if (isLegalReflectiveAccess(method.getDeclaringClass())) {
+					ReflectionUtils.makeAccessible(method);
+					boolean hasAnnotation = Arrays.stream(method.getAnnotations())
+						.map(Annotation::annotationType)
+						.anyMatch(Parameter.class::equals);
+					isSupported.compareAndSet(false, hasAnnotation);
+				}
+			});
+		}
 		return isSupported.get();
 	}
 
@@ -124,13 +119,18 @@ public class JCommanderParameterResolver implements ParameterResolver {
 	}
 
 	/**
-	 * Return <em>all</em> JCommander parameter descriptions, including the "main" parameter if present.
-	 */
+		* Return <em>all</em> JCommander parameter descriptions, including the "main" parameter if present.
+		*/
 	private Stream<com.beust.jcommander.ParameterDescription> streamAllJCommanderDescriptions(JCommander jCommander) {
 		return Stream.concat(
-				jCommander.getParameters().stream(),
-				jCommander.getMainParameter() != null ? Stream.of(jCommander.getMainParameter()) : Stream.empty()
-			);
+			jCommander.getParameters().stream(),
+			jCommander.getMainParameter() != null ? Stream.of(jCommander.getMainParameter()) : Stream.empty()
+		);
+	}
+
+	// Java 9+ warn if you try to reflect on JDK types
+	private static boolean isLegalReflectiveAccess(Class<?> clzz) {
+		return (!clzz.getName().startsWith("java"));
 	}
 
 	@Override


### PR DESCRIPTION
I want to run Spring Shell on Java 9+. I'm using Java 11. It barks when we reflectively try to change the visibility of fields/methods on classes in the JDK. 