### PR TITLE
Update JCommander version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
 		<jline.version>3.4.0</jline.version>
 		<assertj.version>3.8.0</assertj.version>
 		<java.version>1.8</java.version>
-		<jcommander.version>1.48</jcommander.version>
+		<jcommander.version>1.72</jcommander.version>
 		<shell1.version>1.2.0.RELEASE</shell1.version>
 	</properties>
 	

--- a/spring-shell-jcommander-adapter/src/main/java/org/springframework/shell/jcommander/JCommanderParameterResolver.java
+++ b/spring-shell-jcommander-adapter/src/main/java/org/springframework/shell/jcommander/JCommanderParameterResolver.java
@@ -104,9 +104,7 @@ public class JCommanderParameterResolver implements ParameterResolver {
 
 	private JCommander createJCommander(MethodParameter methodParameter) {
 		Object pojo = BeanUtils.instantiateClass(methodParameter.getParameterType());
-		JCommander jCommander = new JCommander(pojo);
-		jCommander.setAcceptUnknownOptions(true);
-		return jCommander;
+		return new JCommander(pojo);
 	}
 
 	@Override
@@ -122,7 +120,7 @@ public class JCommanderParameterResolver implements ParameterResolver {
 						unCamelify(j.getParameterized().getType().getSimpleName()))
 								.keys(Arrays.asList(j.getParameter().names()))
 								.help(j.getDescription())
-								.mandatoryKey(!j.equals(jCommander.getMainParameter()))
+								.mandatoryKey(!j.equals(jCommander.getMainParameterValue()))
 								// Not ideal as this does not take reverse-conversion into account, but just toString()
 								.defaultValue(j.getDefault() == null ? "" : String.valueOf(j.getDefault()))
 								.elementDescriptor(
@@ -136,7 +134,7 @@ public class JCommanderParameterResolver implements ParameterResolver {
 	private Stream<com.beust.jcommander.ParameterDescription> streamAllJCommanderDescriptions(JCommander jCommander) {
 		return Stream.concat(
 				jCommander.getParameters().stream(),
-				jCommander.getMainParameter() != null ? Stream.of(jCommander.getMainParameter()) : Stream.empty());
+				jCommander.getMainParameterValue() != null ? Stream.of(jCommander.getMainParameterValue()) : Stream.empty());
 	}
 
 	// Java 9+ warn if you try to reflect on JDK types


### PR DESCRIPTION
This commit updates the JCommander version to 1.72.
The update also takes into account an issue that was introduced in new versions of the JCommander, namely, https://github.com/cbeust/jcommander/issues/377.