### PR TITLE
Allow empty input with double quotes.

### DIFF
--- a/spring-shell-standard/src/main/java/org/springframework/shell/standard/StandardParameterResolver.java
+++ b/spring-shell-standard/src/main/java/org/springframework/shell/standard/StandardParameterResolver.java
@@ -88,7 +88,6 @@ import javax.validation.metadata.ParameterDescriptor;
  * @author Florent Biville
  * @author Camilo Gonzalez
  */
-@Component
 public class StandardParameterResolver implements ParameterResolver {
 
 	private final ConversionService conversionService;
@@ -129,9 +128,8 @@ public class StandardParameterResolver implements ParameterResolver {
 
 	@Override
 	public ValueResult resolve(MethodParameter methodParameter, List<String> wordsBuffer) {
-		String prefix = prefixForMethod(methodParameter.getMethod());
 
-		List<String> words = wordsBuffer.stream().filter(w -> !w.isEmpty()).collect(Collectors.toList());
+		List<String> words = wordsBuffer.stream().filter(w -> w != null).collect(Collectors.toList());
 
 		CacheKey cacheKey = new CacheKey(methodParameter.getMethod(), wordsBuffer);
 		parameterCache.clear();


### PR DESCRIPTION
Empty input with double quotes("") was not allowed because of filtering empty string in StandardParameterResolver.resolve().
Assuming ShellMethod test(String a, @ShellOption(defaultValue = "") String b) and input 'test "" B'. Expected parameter is (a="", b="B"). But result is (a="B", b="").
So I remove filtering in StandardParameterResolver.resolve().

And remove unnecessary code.

I tested few method and It seems fine. But I am worrying about side effects. Please check my modification.