### PR TITLE
URL Cleanup

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
     repositories {
-        maven { url 'http://repo.springsource.org/plugins-release' }
+        maven { url 'https://repo.springsource.org/plugins-release' }
     }
     dependencies {
         classpath 'io.spring.gradle:docbook-reference-plugin:0.3.1'
@@ -13,8 +13,8 @@ group = 'org.springframework.shell'
 
 repositories {
   mavenCentral()
-  maven { url "http://repo.springsource.org/libs-snapshot" }
-  maven { url "http://repo.springsource.org/plugins-release" }
+  maven { url "https://repo.springsource.org/libs-snapshot" }
+  maven { url "https://repo.springsource.org/plugins-release" }
 }
 
 apply plugin: "java"
@@ -73,8 +73,8 @@ javadoc {
       ]
   
      links = [
-        "http://static.springframework.org/spring/docs/3.1.x/javadoc-api",
-        "http://download.oracle.com/javase/6/docs/api",
+        "https://docs.spring.io/spring/docs/3.1.x/javadoc-api",
+        "https://download.oracle.com/javase/6/docs/api",
      ]
      
      //exclude "org/springframework/data/redis/config/**"

--- a/maven.gradle
+++ b/maven.gradle
@@ -31,20 +31,20 @@ def customizePom(pom, gradleProject) {
         generatedPom.project {
             name = gradleProject.description
             description = gradleProject.description
-            url = 'http://github.com/SpringSource/spring-shell'
+            url = 'https://github.com/SpringSource/spring-shell'
             organization {
                 name = 'SpringSource'
-                url = 'http://www.springsource.org/spring-shell'
+                url = 'https://www.springsource.org/spring-shell'
             }
             licenses {
                 license {
                     name 'The Apache Software License, Version 2.0'
-                    url 'http://www.apache.org/licenses/LICENSE-2.0.txt'
+                    url 'https://www.apache.org/licenses/LICENSE-2.0.txt'
                     distribution 'repo'
                 }
             }
             scm {
-                url = 'http://github.com/SpringSource/spring-shell'
+                url = 'https://github.com/SpringSource/spring-shell'
                 connection = 'scm:git:git://github.com/SpringSource/spring-shell'
                 developerConnection = 'scm:git:git://github.com/SpringSource/spring-shell'
             }

--- a/samples/helloworld/build.gradle
+++ b/samples/helloworld/build.gradle
@@ -5,8 +5,8 @@ apply plugin: 'eclipse'
 apply plugin: 'application'
 
 repositories {
-	maven { url "http://repo.springsource.org/libs-milestone" }
-	maven { url "http://repo.springsource.org/libs-release" }
+	maven { url "https://repo.springsource.org/libs-milestone" }
+	maven { url "https://repo.springsource.org/libs-release" }
 	mavenLocal()
 	mavenCentral()
 }

--- a/samples/helloworld/pom.xml
+++ b/samples/helloworld/pom.xml
@@ -1,5 +1,5 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
 	<groupId>org.springframework.shell.samples</groupId>
@@ -8,7 +8,7 @@
 	<packaging>jar</packaging>
 
 	<name>helloworld</name>
-	<url>http://maven.apache.org</url>
+	<url>https://maven.apache.org</url>
 
 	<properties>
 		<spring.shell.version>1.2.0.RELEASE</spring.shell.version>
@@ -91,11 +91,11 @@
 	  <repositories>
 	    <repository>
 	      <id>libs-milestone</id>
-	      <url>http://repo.spring.io/libs-milestone/</url>
+	      <url>https://repo.spring.io/libs-milestone/</url>
 	    </repository>
 	    <repository>
 	      <id>libs-release</id>
-	      <url>http://repo.spring.io/libs-release/</url>
+	      <url>https://repo.spring.io/libs-release/</url>
 	    </repository>
 	  </repositories>
 </project>


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://maven.apache.org with 1 occurrences migrated to:  
  https://maven.apache.org ([https](https://maven.apache.org) result 200).
* http://maven.apache.org/xsd/maven-4.0.0.xsd with 1 occurrences migrated to:  
  https://maven.apache.org/xsd/maven-4.0.0.xsd ([https](https://maven.apache.org/xsd/maven-4.0.0.xsd) result 200).
* http://repo.spring.io/libs-milestone/ with 1 occurrences migrated to:  
  https://repo.spring.io/libs-milestone/ ([https](https://repo.spring.io/libs-milestone/) result 200).
* http://repo.spring.io/libs-release/ with 1 occurrences migrated to:  
  https://repo.spring.io/libs-release/ ([https](https://repo.spring.io/libs-release/) result 200).
* http://www.apache.org/licenses/LICENSE-2.0.txt with 1 occurrences migrated to:  
  https://www.apache.org/licenses/LICENSE-2.0.txt ([https](https://www.apache.org/licenses/LICENSE-2.0.txt) result 200).
* http://static.springframework.org/spring/docs/3.1.x/javadoc-api (301) with 1 occurrences migrated to:  
  https://docs.spring.io/spring/docs/3.1.x/javadoc-api ([https](https://static.springframework.org/spring/docs/3.1.x/javadoc-api) result 301).
* http://github.com/SpringSource/spring-shell with 2 occurrences migrated to:  
  https://github.com/SpringSource/spring-shell ([https](https://github.com/SpringSource/spring-shell) result 301).
* http://repo.springsource.org/libs-milestone with 1 occurrences migrated to:  
  https://repo.springsource.org/libs-milestone ([https](https://repo.springsource.org/libs-milestone) result 301).
* http://repo.springsource.org/libs-release with 1 occurrences migrated to:  
  https://repo.springsource.org/libs-release ([https](https://repo.springsource.org/libs-release) result 301).
* http://repo.springsource.org/libs-snapshot with 1 occurrences migrated to:  
  https://repo.springsource.org/libs-snapshot ([https](https://repo.springsource.org/libs-snapshot) result 301).
* http://repo.springsource.org/plugins-release with 2 occurrences migrated to:  
  https://repo.springsource.org/plugins-release ([https](https://repo.springsource.org/plugins-release) result 301).
* http://www.springsource.org/spring-shell with 1 occurrences migrated to:  
  https://www.springsource.org/spring-shell ([https](https://www.springsource.org/spring-shell) result 301).
* http://download.oracle.com/javase/6/docs/api with 1 occurrences migrated to:  
  https://download.oracle.com/javase/6/docs/api ([https](https://download.oracle.com/javase/6/docs/api) result 302).

# Ignored
These URLs were intentionally ignored.

* http://maven.apache.org/POM/4.0.0 with 2 occurrences
* http://www.w3.org/2001/XMLSchema-instance with 1 occurrences