### PR TITLE
URL Cleanup

### DIFF
--- a/docs/src/reference/docbook/introduction/requirements.xml
+++ b/docs/src/reference/docbook/introduction/requirements.xml
@@ -9,6 +9,6 @@
   <title>Requirements</title>
 
   <para>The Spring Shell requires JDK level 6.0 and above as well as the
-  <ulink url="http://www.springsource.org/about">Spring Framework</ulink> 3.0
+  <ulink url="https://www.springsource.org/about">Spring Framework</ulink> 3.0
   (3.1 recommended) and above.</para>
 </chapter>

--- a/docs/src/reference/docbook/preface.xml
+++ b/docs/src/reference/docbook/preface.xml
@@ -12,7 +12,7 @@
   model.</para>
 
   <para>The shell has been extracted from the <link
-  ns2:href="http://www.springsource.org/spring-roo/">Spring Roo
+  ns2:href="https://www.springsource.org/spring-roo/">Spring Roo
   project</link>, giving it a strong foundation and rich feature set. One
   significant change from Spring Roo is that the plugin model is no longer
   based on OSGi but instead uses the Spring IoC container to discover commands
@@ -34,7 +34,7 @@
 
     <listitem>
       <para>Inheritance of the <link
-      ns2:href="http://static.springsource.org/spring-roo/reference/html-single/index.html#usage-shell">Roo
+      ns2:href="https://docs.spring.io/spring-roo/reference/html-single/index.html#usage-shell">Roo
       Shell features</link>, most notably tab completion, colorization, and
       script execution.</para>
     </listitem>

--- a/docs/src/reference/docbook/reference/dev-guide/dev-spring-shell.xml
+++ b/docs/src/reference/docbook/reference/dev-guide/dev-spring-shell.xml
@@ -214,7 +214,7 @@ public class HelloWorldCommands implements CommandMarker {
     application plugin from gradle to create a bin directory with a startup
     script for windows and Unix and places all dependent jars in a lib
     directory. Maven has a similar plugin - the <link
-    xlink:href="http://mojo.codehaus.org/appassembler/appassembler-maven-plugin/">AppAssembler</link>
+    xlink:href="https://mojo.codehaus.org/appassembler/appassembler-maven-plugin/">AppAssembler</link>
     plugin.</para>
 
     <para>The main class of the shell is

--- a/docs/src/reference/docbook/reference/shell.xml
+++ b/docs/src/reference/docbook/reference/shell.xml
@@ -53,9 +53,9 @@
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:context="http://www.springframework.org/schema/context"
        xsi:schemaLocation="http://www.springframework.org/schema/beans 
-       http://www.springframework.org/schema/beans/spring-beans.xsd
+       https://www.springframework.org/schema/beans/spring-beans.xsd
        http://www.springframework.org/schema/context 
-       http://www.springframework.org/schema/context/spring-context-3.1.xsd"&gt;
+       https://www.springframework.org/schema/context/spring-context-3.1.xsd"&gt;
 
   &lt;context:component-scan 
            base-package="org.springframework.shell.samples.helloworld.commands" /&gt;
@@ -203,9 +203,9 @@ public class HelloWorldCommands implements CommandMarker {
     other plugins.</para>
 
     <para>To make cool "<link
-    xlink:href="http://en.wikipedia.org/wiki/ASCII_art">ASCII art</link>"
+    xlink:href="https://en.wikipedia.org/wiki/ASCII_art">ASCII art</link>"
     banners the website <link
-    xlink:href="http://patorjk.com/software/taag">http://patorjk.com/software/taag</link>
+    xlink:href="http://patorjk.com/software/taag/">http://patorjk.com/software/taag/</link>
     is quite neat!</para>
   </section>
 
@@ -272,7 +272,7 @@ public class HelloWorldCommands implements CommandMarker {
       <listitem>
         <para><literal>--profiles</literal> - Specifies values for the system
         property spring.profiles.active so that Spring 3.1 and greater <link
-        xlink:href="http://blog.springsource.com/2011/02/11/spring-framework-3-1-m1-released/">profile
+        xlink:href="https://spring.io/blog/2011/02/11/spring-framework-3-1-m1-released/">profile
         support </link>is enabled.</para>
       </listitem>
 

--- a/samples/helloworld/pom.xml
+++ b/samples/helloworld/pom.xml
@@ -1,5 +1,5 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
 	<groupId>org.springframework.shell.samples</groupId>
@@ -8,7 +8,7 @@
 	<packaging>jar</packaging>
 
 	<name>helloworld</name>
-	<url>http://maven.apache.org</url>
+	<url>https://maven.apache.org</url>
 
 	<properties>
 		<spring.shell.version>1.2.0.RELEASE</spring.shell.version>
@@ -91,11 +91,11 @@
 	  <repositories>
 	    <repository>
 	      <id>libs-milestone</id>
-	      <url>http://repo.spring.io/libs-milestone/</url>
+	      <url>https://repo.spring.io/libs-milestone/</url>
 	    </repository>
 	    <repository>
 	      <id>libs-release</id>
-	      <url>http://repo.spring.io/libs-release/</url>
+	      <url>https://repo.spring.io/libs-release/</url>
 	    </repository>
 	  </repositories>
 </project>

--- a/samples/helloworld/src/main/resources/META-INF/spring/spring-shell-plugin.xml
+++ b/samples/helloworld/src/main/resources/META-INF/spring/spring-shell-plugin.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:context="http://www.springframework.org/schema/context"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd">
 
 	<context:component-scan base-package="org.springframework.shell.samples.helloworld.commands" />
 

--- a/src/test/resources/META-INF/spring/spring-shell-plugin.xml
+++ b/src/test/resources/META-INF/spring/spring-shell-plugin.xml
@@ -2,8 +2,8 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xmlns:context="http://www.springframework.org/schema/context"
-	xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-		http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context-3.1.xsd">
+	xsi:schemaLocation="http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd
+		http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context-3.1.xsd">
 
 	<context:component-scan base-package="org.springframework.shell.commands.test"/>
 


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# HTTP URLs that Could Not Be Fixed
These URLs were unable to be fixed. Please review them to see if they can be manually resolved.

* [ ] http://patorjk.com/software/taag (301) with 2 occurrences could not be migrated:  
   ([https](https://patorjk.com/software/taag) result SSLHandshakeException).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* [ ] http://mojo.codehaus.org/appassembler/appassembler-maven-plugin/ (UnknownHostException) with 1 occurrences migrated to:  
  https://mojo.codehaus.org/appassembler/appassembler-maven-plugin/ ([https](https://mojo.codehaus.org/appassembler/appassembler-maven-plugin/) result UnknownHostException).
* [ ] http://static.springsource.org/spring-roo/reference/html-single/index.html (301) with 1 occurrences migrated to:  
  https://docs.spring.io/spring-roo/reference/html-single/index.html ([https](https://static.springsource.org/spring-roo/reference/html-single/index.html) result 404).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://en.wikipedia.org/wiki/ASCII_art with 1 occurrences migrated to:  
  https://en.wikipedia.org/wiki/ASCII_art ([https](https://en.wikipedia.org/wiki/ASCII_art) result 200).
* [ ] http://maven.apache.org with 1 occurrences migrated to:  
  https://maven.apache.org ([https](https://maven.apache.org) result 200).
* [ ] http://maven.apache.org/xsd/maven-4.0.0.xsd with 1 occurrences migrated to:  
  https://maven.apache.org/xsd/maven-4.0.0.xsd ([https](https://maven.apache.org/xsd/maven-4.0.0.xsd) result 200).
* [ ] http://repo.spring.io/libs-milestone/ with 1 occurrences migrated to:  
  https://repo.spring.io/libs-milestone/ ([https](https://repo.spring.io/libs-milestone/) result 200).
* [ ] http://repo.spring.io/libs-release/ with 1 occurrences migrated to:  
  https://repo.spring.io/libs-release/ ([https](https://repo.spring.io/libs-release/) result 200).
* [ ] http://blog.springsource.com/2011/02/11/spring-framework-3-1-m1-released/ (301) with 1 occurrences migrated to:  
  https://spring.io/blog/2011/02/11/spring-framework-3-1-m1-released/ ([https](https://blog.springsource.com/2011/02/11/spring-framework-3-1-m1-released/) result 200).
* [ ] http://www.springframework.org/schema/beans/spring-beans.xsd with 3 occurrences migrated to:  
  https://www.springframework.org/schema/beans/spring-beans.xsd ([https](https://www.springframework.org/schema/beans/spring-beans.xsd) result 200).
* [ ] http://www.springframework.org/schema/context/spring-context-3.1.xsd with 2 occurrences migrated to:  
  https://www.springframework.org/schema/context/spring-context-3.1.xsd ([https](https://www.springframework.org/schema/context/spring-context-3.1.xsd) result 200).
* [ ] http://www.springframework.org/schema/context/spring-context.xsd with 1 occurrences migrated to:  
  https://www.springframework.org/schema/context/spring-context.xsd ([https](https://www.springframework.org/schema/context/spring-context.xsd) result 200).
* [ ] http://www.springsource.org/about with 1 occurrences migrated to:  
  https://www.springsource.org/about ([https](https://www.springsource.org/about) result 302).
* [ ] http://www.springsource.org/spring-roo/ with 1 occurrences migrated to:  
  https://www.springsource.org/spring-roo/ ([https](https://www.springsource.org/spring-roo/) result 302).

# Ignored
These URLs were intentionally ignored.

* http://docbook.org/ns/docbook with 13 occurrences
* http://maven.apache.org/POM/4.0.0 with 2 occurrences
* http://www.springframework.org/schema/beans with 6 occurrences
* http://www.springframework.org/schema/context with 6 occurrences
* http://www.w3.org/1998/Math/MathML with 6 occurrences
* http://www.w3.org/1999/xhtml with 6 occurrences
* http://www.w3.org/1999/xlink with 7 occurrences
* http://www.w3.org/2000/svg with 6 occurrences
* http://www.w3.org/2001/XInclude with 4 occurrences
* http://www.w3.org/2001/XMLSchema-instance with 4 occurrences