### PR TITLE
URL Cleanup

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -3,13 +3,13 @@
 
 Spring Shell is an shell skeleton that can be easily extended with commands using a Spring based programming model. Spring Shell eases the creation of interactive console applications, featuring ANSI coloring, TAB completion, history browsing, _etc._
 
-To witness possibilities of Spring Shell, have a look at the http://docs.spring.io/spring-xd/docs/current-SNAPSHOT/reference/html/#interactive-shell[Spring XD Shell].
+To witness possibilities of Spring Shell, have a look at the https://docs.spring.io/spring-xd/docs/current-SNAPSHOT/reference/html/#interactive-shell[Spring XD Shell].
 
 The latest release version is {currentReleaseVersion}, while the development version is {currentSnapshotVersion}.
 
 # Useful links
 
-* http://static.springsource.org/spring-shell/docs/current/reference/[User documentation]
+* https://docs.spring.io/spring-shell/docs/current/reference/[User documentation]
 * https://jira.spring.io/browse/SHL[Issue Tracker]
 
 # Artifacts
@@ -21,14 +21,14 @@ The latest release version is {currentReleaseVersion}, while the development ver
  <!-- Release -->
  <id>spring-release</id>
  <name>Spring Maven RELEASE Repository</name>
- <url>http://repo.springframework.org/release</url>
+ <url>https://repo.springframework.org/release</url>
 </repository>
 
 <!-- libs-release artifacts that may not be in maven central -->
 <repository>
  <id>libs-release</id>
  <name>Spring Maven libs-release Repository</name>
- <url>http://repo.springframework.org/libs-release</url>
+ <url>https://repo.springframework.org/libs-release</url>
 </repository>
 
 <dependency>
@@ -42,7 +42,7 @@ The latest release version is {currentReleaseVersion}, while the development ver
  <!-- Snapshots -->
  <id>spring-snapshot</id>
  <name>Spring Maven SNAPSHOT Repository</name>
- <url>http://repo.springframework.org/libs-snapshot</url>
+ <url>https://repo.springframework.org/libs-snapshot</url>
 </repository>
 
 <dependency>
@@ -58,7 +58,7 @@ The latest release version is {currentReleaseVersion}, while the development ver
 [subs="attributes,specialcharacters"]
 ----
 repositories {
-   maven { url "http://repo.springsource.org/lib-release" }
+   maven { url "https://repo.springsource.org/lib-release" }
 }
 
 dependencies {
@@ -83,6 +83,6 @@ Spring Shell is built with Gradle. To build Spring Shell, run
 
 Here are some ways for you to get involved in the community:
 
-* Get involved with the Spring community on Stack Overflow. Please help out on the http://stackoverflow.com/questions/tagged/spring-shell[dedicated SO tag] by responding to questions and joining the debate.
+* Get involved with the Spring community on Stack Overflow. Please help out on the https://stackoverflow.com/questions/tagged/spring-shell[dedicated SO tag] by responding to questions and joining the debate.
 * Create https://jira.spring.io/browse/SHL[JIRA] tickets for bugs and new features and comment and vote on the ones that you are interested in.  
-Github is for social coding: if you want to write code, we encourage contributions through pull requests from http://help.github.com/forking/[forks of this repository]. If you want to contribute code this way, please reference a JIRA tracker ticket covering the specific issue you are addressing. Before we accept a non-trivial patch or pull request we will need you to sign the https://support.springsource.com/spring_committer_signup[contributor's agreement].  Signing the contributor's agreement does not grant anyone commit rights to the main repository, but it does mean that we can accept your contributions, and you will get an author credit if we do.  Active contributors might be asked to join the core team, and given the ability to merge pull requests.
+Github is for social coding: if you want to write code, we encourage contributions through pull requests from https://help.github.com/forking/[forks of this repository]. If you want to contribute code this way, please reference a JIRA tracker ticket covering the specific issue you are addressing. Before we accept a non-trivial patch or pull request we will need you to sign the https://support.springsource.com/spring_committer_signup[contributor's agreement].  Signing the contributor's agreement does not grant anyone commit rights to the main repository, but it does mean that we can accept your contributions, and you will get an author credit if we do.  Active contributors might be asked to join the core team, and given the ability to merge pull requests.

--- a/docs/src/api/overview.html
+++ b/docs/src/api/overview.html
@@ -7,7 +7,7 @@ This document is the API specification for the Spring Shell project.
 <!--
 	<p>
 		For further API reference and developer documentation, see the
-		<a href="http://static.springframework.org/spring/docs/2.0.x/reference/index.html" target="_top">Spring Framework reference documentation</a>.
+		<a href="https://docs.spring.io/spring/docs/2.0.x/reference/index.html" target="_top">Spring Framework reference documentation</a>.
 		That documentation contains more detailed, developer-targeted
 		descriptions, with conceptual overviews, definitions of terms,
 		workarounds, and working code examples.
@@ -16,7 +16,7 @@ This document is the API specification for the Spring Shell project.
 	<p>
 		If you are interested in commercial training, consultancy and
 		support for the Spring Shell project,
-		<a href="http://www.SpringSource.com/" target="_top">SpringSource</a> provides
+		<a href="https://www.SpringSource.com/" target="_top">SpringSource</a> provides
 		such commercial support.
 	</p>
 </div>

--- a/docs/src/info/changelog.txt
+++ b/docs/src/info/changelog.txt
@@ -1,9 +1,9 @@
 SPRING SHELL CHANGELOG
 ======================
-http://www.springsource.org/spring-shell
+https://www.springsource.org/spring-shell
 
-Commit changelog: http://github.com/SpringSource/spring-shell/tree/[version]
-Issues changelog: http://jira.springsource.org/secure/ReleaseNote.jspa?projectId=10361
+Commit changelog: https://github.com/SpringSource/spring-shell/tree/[version]
+Issues changelog: https://jira.springsource.org/secure/ReleaseNote.jspa?projectId=10361
 
 Changes in version 1.1.0 RELEASE (2014-7-25)
 -------------------------------------

--- a/docs/src/info/notice.txt
+++ b/docs/src/info/notice.txt
@@ -4,13 +4,13 @@
    ======================================================================
 
    This product includes software developed by
-   the Apache Software Foundation (http://www.apache.org).
+   the Apache Software Foundation (https://www.apache.org).
 
    The end-user documentation included with a redistribution, if any,
    must include the following acknowledgement:
 
      "This product includes software developed by the Spring Framework
-      Project (http://www.springframework.org)."
+      Project (https://www.springframework.org)."
 
    Alternately, this acknowledgement may appear in the software itself,
    if and wherever such third-party acknowledgements normally appear.

--- a/docs/src/info/readme.txt
+++ b/docs/src/info/readme.txt
@@ -23,4 +23,4 @@ as sections of interest in the reference documentation.
 
 5. ADDITIONAL RESOURCES
 
-Spring Shell homepage: http://www.springsource.org/spring-shell
+Spring Shell homepage: https://www.springsource.org/spring-shell

--- a/src/main/java/org/springframework/shell/core/AbstractShell.java
+++ b/src/main/java/org/springframework/shell/core/AbstractShell.java
@@ -115,7 +115,7 @@ public abstract class AbstractShell extends AbstractShellStatusPublisher impleme
 				line = line.substring(line.lastIndexOf("*/") + 2);
 			}
 			// We also support inline comments (but only at start of line, otherwise valid
-			// command options like http://www.helloworld.com will fail as per ROO-517)
+			// command options like https://www.helloworld.com will fail as per ROO-517)
 			if (!inBlockComment && (line.trim().startsWith("//") || line.trim().startsWith("#"))) { // # support in ROO-1116
 				line = "";
 			}

--- a/src/main/java/org/springframework/shell/core/JLineShell.java
+++ b/src/main/java/org/springframework/shell/core/JLineShell.java
@@ -50,12 +50,12 @@ import org.springframework.util.ObjectUtils;
 import org.springframework.util.StringUtils;
 
 /**
- * Uses the feature-rich <a href="http://sourceforge.net/projects/jline/">JLine</a> library to provide an interactive
+ * Uses the feature-rich <a href="https://sourceforge.net/projects/jline/">JLine</a> library to provide an interactive
  * shell.
  * 
  * <p>
  * Due to Windows' lack of color ANSI services out-of-the-box, this implementation automatically detects the classpath
- * presence of <a href="http://jansi.fusesource.org/">Jansi</a> and uses it if present. This library is not necessary
+ * presence of <a href="https://jansi.fusesource.org/">Jansi</a> and uses it if present. This library is not necessary
  * for *nix machines, which support colour ANSI without any special effort. This implementation has been written to use
  * reflection in order to avoid hard dependencies on Jansi.
  * 


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# HTTP URLs that Could Not Be Fixed
These URLs were unable to be fixed. Please review them to see if they can be manually resolved.

* [ ] http://www.unicode.org/glossary/ (200) with 1 occurrences could not be migrated:  
   ([https](https://www.unicode.org/glossary/) result SSLProtocolException).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* [ ] http://jansi.fusesource.org/ (ConnectTimeoutException) with 1 occurrences migrated to:  
  https://jansi.fusesource.org/ ([https](https://jansi.fusesource.org/) result ConnectTimeoutException).
* [ ] http://github.com/SpringSource/spring-shell/tree/ (301) with 1 occurrences migrated to:  
  https://github.com/SpringSource/spring-shell/tree/ ([https](https://github.com/SpringSource/spring-shell/tree/) result 404).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://static.springsource.org/spring-shell/docs/current/reference/ (301) with 1 occurrences migrated to:  
  https://docs.spring.io/spring-shell/docs/current/reference/ ([https](https://static.springsource.org/spring-shell/docs/current/reference/) result 200).
* [ ] http://docs.spring.io/spring-xd/docs/current-SNAPSHOT/reference/html/ with 1 occurrences migrated to:  
  https://docs.spring.io/spring-xd/docs/current-SNAPSHOT/reference/html/ ([https](https://docs.spring.io/spring-xd/docs/current-SNAPSHOT/reference/html/) result 200).
* [ ] http://static.springframework.org/spring/docs/2.0.x/reference/index.html (301) with 1 occurrences migrated to:  
  https://docs.spring.io/spring/docs/2.0.x/reference/index.html ([https](https://static.springframework.org/spring/docs/2.0.x/reference/index.html) result 200).
* [ ] http://sourceforge.net/projects/jline/ with 1 occurrences migrated to:  
  https://sourceforge.net/projects/jline/ ([https](https://sourceforge.net/projects/jline/) result 200).
* [ ] http://stackoverflow.com/questions/tagged/spring-shell with 1 occurrences migrated to:  
  https://stackoverflow.com/questions/tagged/spring-shell ([https](https://stackoverflow.com/questions/tagged/spring-shell) result 200).
* [ ] http://www.apache.org with 1 occurrences migrated to:  
  https://www.apache.org ([https](https://www.apache.org) result 200).
* [ ] http://www.helloworld.com with 1 occurrences migrated to:  
  https://www.helloworld.com ([https](https://www.helloworld.com) result 200).
* [ ] http://help.github.com/forking/ with 1 occurrences migrated to:  
  https://help.github.com/forking/ ([https](https://help.github.com/forking/) result 301).
* [ ] http://jira.springsource.org/secure/ReleaseNote.jspa?projectId=10361 with 1 occurrences migrated to:  
  https://jira.springsource.org/secure/ReleaseNote.jspa?projectId=10361 ([https](https://jira.springsource.org/secure/ReleaseNote.jspa?projectId=10361) result 301).
* [ ] http://repo.springsource.org/lib-release with 1 occurrences migrated to:  
  https://repo.springsource.org/lib-release ([https](https://repo.springsource.org/lib-release) result 301).
* [ ] http://www.SpringSource.com/ with 1 occurrences migrated to:  
  https://www.SpringSource.com/ ([https](https://www.SpringSource.com/) result 301).
* [ ] http://www.springframework.org with 1 occurrences migrated to:  
  https://www.springframework.org ([https](https://www.springframework.org) result 301).
* [ ] http://www.springsource.org/spring-shell with 2 occurrences migrated to:  
  https://www.springsource.org/spring-shell ([https](https://www.springsource.org/spring-shell) result 301).
* [ ] http://repo.springframework.org/libs-release with 1 occurrences migrated to:  
  https://repo.springframework.org/libs-release ([https](https://repo.springframework.org/libs-release) result 302).
* [ ] http://repo.springframework.org/libs-snapshot with 1 occurrences migrated to:  
  https://repo.springframework.org/libs-snapshot ([https](https://repo.springframework.org/libs-snapshot) result 302).
* [ ] http://repo.springframework.org/release with 1 occurrences migrated to:  
  https://repo.springframework.org/release ([https](https://repo.springframework.org/release) result 302).