### PR TITLE
URL Cleanup

### DIFF
--- a/samples/helloworld/build.gradle
+++ b/samples/helloworld/build.gradle
@@ -8,7 +8,7 @@ repositories {
 	maven { url "https://repo.springsource.org/libs-milestone" }
 	maven { url "https://repo.springsource.org/libs-release" }
 	mavenLocal()
-	mavenCentral()
+	maven { url 'https://repo.maven.apache.org/maven2/' }
 }
 
 dependencies {

--- a/samples/helloworld/gradle/wrapper/gradle-wrapper.properties
+++ b/samples/helloworld/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-1.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-1.2-bin.zip


### PR DESCRIPTION
- Ensure Gradle Wrapper is downloaded via https
- This project uses an old version of Gradle in which mavenCentral() and
  jcenter() use http instead of https. This commit switches to use an
  explicit URL so https is used.