### PR TITLE
Add quick start reference to README

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -18,3 +18,5 @@ The project comes with a sample application, showcasing the various ways you can
 
 From there, try typing `help` or `help <commmand>` at the shell prompt.
 
+== Quick Start
+See instructions on wbe site: https://projects.spring.io/spring-shell/

--- a/README.adoc
+++ b/README.adoc
@@ -19,4 +19,4 @@ The project comes with a sample application, showcasing the various ways you can
 From there, try typing `help` or `help <commmand>` at the shell prompt.
 
 == Quick Start
-See instructions on wbe site: https://projects.spring.io/spring-shell/
+See instructions on web site: https://projects.spring.io/spring-shell/


### PR DESCRIPTION
It is nice to have instruction on how to start with the project in README file. 

Please alsow check comments to the [issue](https://github.com/spring-projects/spring-shell/issues/247) about quick start page content.