### PR TITLE
Clarify how to achieve varying arity in docs

### DIFF
--- a/spring-shell-docs/src/main/asciidoc/using-spring-shell.adoc
+++ b/spring-shell-docs/src/main/asciidoc/using-spring-shell.adoc
@@ -300,8 +300,27 @@ shell:>add --numbers 1 --numbers 2 --numbers 3.3
 ----
 ====
 
-===== Infinite Arity
-TO BE IMPLEMENTED
+===== Varying Amount Arity
+
+The above example demonstrates requiring a known, constant arity for a parameter, three in this case. Allowing any number of multiple values of a parameter can be achieved by leaving `arity` unspecified and using Spring's built-in comma separated value parsing for collections and/or arrays:
+[source, java]
+----
+	@ShellMethod("Add a Varying Amount of Numbers.")
+	public double add(@ShellOption double[] numbers) {
+		return Arrays.stream(numbers).sum();
+	}
+----
+
+The command may then be invoked with any amount of `numbers`:
+[source]
+----
+shell:>add 1,2,3.3
+6.3
+shell:>add --numbers 42
+42.0
+shell:>add --numbers 1,2,3.3,4,5
+15.3
+----
 
 ===== Special Handling of Boolean Parameters
 When it comes to parameter arity, there is a kind of parameters that receives a special treatment by default, as


### PR DESCRIPTION
Add examples of how to achieve, with existing functionality, a varying amount of parameter arity (and favor this verbage over "infinite", which, though technically true, could be misleading for evoking neding a very large amount of a parameter, instead of the normal usecase of a few of any amount).

The docs have long said "TO BE IMPLEMENTED", however this functionality is already achievable. I needed this (common IMO) use case and searched in the docs, plus found some long standing open issues like [here](https://github.com/spring-projects/spring-shell/issues/140) and [here](https://github.com/spring-projects/spring-shell/issues/235), but was happy to find I could get it to work without needing any new features.