### PR TITLE
fix flaky test

### DIFF
--- a/spring-shell-test-samples/src/test/java/com/example/test/integration/CalculatorCommandsIntegrationTest.java
+++ b/spring-shell-test-samples/src/test/java/com/example/test/integration/CalculatorCommandsIntegrationTest.java
@@ -38,6 +38,11 @@ public class CalculatorCommandsIntegrationTest extends BaseCalculatorTest {
 	@Autowired
 	private CalculatorState state;
 
+    @Before
+	public void setup() {
+		state.clear();
+	}
+    
 	/**
 	 * Test "happy path" or basic addition with positive numbers and zeroes. Use Spring Shell
 	 * auto-wired by the Spring Test Runner.


### PR DESCRIPTION
Added setup() method to clear the calculator state's memory to avoid tests being Flaky. 
