### PR TITLE
Fix Travis build config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,9 @@
-sudo: false
 language: java
 cache:
   directories:
     - $HOME/.m2
 jdk:
-  - oraclejdk8
+  - openjdk8
 install: true
 build: ./mvnw package
 after_success:


### PR DESCRIPTION
https://docs.travis-ci.com/user/reference/trusty/ says:
Container-based infrastructure is currently being deprecated. Please
remove any `sudo: false` keys in your `.travis.yml` file to use the
default fully-virtualized Linux infrastructure instead.

Default env. is now Xenial which has only `openjdk8` preinstalled.
See https://docs.travis-ci.com/user/trusty-to-xenial-migration-guide/.