### PR TITLE
Make grouping configurable in build-in help

### DIFF
--- a/spring-shell-autoconfigure/src/main/java/org/springframework/shell/boot/SpringShellProperties.java
+++ b/spring-shell-autoconfigure/src/main/java/org/springframework/shell/boot/SpringShellProperties.java
@@ -126,6 +126,7 @@ public class SpringShellProperties {
 	public static class HelpCommand {
 
 		private boolean enabled = true;
+		private GroupingMode groupingMode = GroupingMode.GROUP;
 
 		public boolean isEnabled() {
 			return enabled;
@@ -133,6 +134,19 @@ public class SpringShellProperties {
 
 		public void setEnabled(boolean enabled) {
 			this.enabled = enabled;
+		}
+
+		public GroupingMode getGroupingMode() {
+			return groupingMode;
+		}
+
+		public void setGroupingMode(GroupingMode groupingMode) {
+			this.groupingMode = groupingMode;
+		}
+
+		public enum GroupingMode {
+			GROUP,
+			FLAT
 		}
 	}
 

--- a/spring-shell-autoconfigure/src/main/java/org/springframework/shell/boot/StandardCommandsAutoConfiguration.java
+++ b/spring-shell-autoconfigure/src/main/java/org/springframework/shell/boot/StandardCommandsAutoConfiguration.java
@@ -29,6 +29,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.shell.boot.SpringShellProperties.VersionCommand;
+import org.springframework.shell.boot.SpringShellProperties.HelpCommand.GroupingMode;
 import org.springframework.shell.boot.condition.OnCompletionCommandCondition;
 import org.springframework.shell.result.ThrowableResultHandler;
 import org.springframework.shell.standard.commands.Clear;
@@ -54,8 +55,12 @@ public class StandardCommandsAutoConfiguration {
 	@Bean
 	@ConditionalOnMissingBean(Help.Command.class)
 	@ConditionalOnProperty(prefix = "spring.shell.command.help", value = "enabled", havingValue = "true", matchIfMissing = true)
-	public Help help() {
-		return new Help();
+	public Help help(SpringShellProperties properties) {
+		Help help = new Help();
+		if (properties.getCommand().getHelp().getGroupingMode() == GroupingMode.FLAT) {
+			help.setShowGroups(false);
+		}
+		return help;
 	}
 
 	@Bean

--- a/spring-shell-autoconfigure/src/test/java/org/springframework/shell/boot/SpringShellPropertiesTests.java
+++ b/spring-shell-autoconfigure/src/test/java/org/springframework/shell/boot/SpringShellPropertiesTests.java
@@ -19,6 +19,7 @@ import org.junit.jupiter.api.Test;
 
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.shell.boot.SpringShellProperties.HelpCommand.GroupingMode;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -38,6 +39,7 @@ public class SpringShellPropertiesTests {
 					assertThat(properties.getTheme().getName()).isEqualTo("default");
 					assertThat(properties.getCommand().getClear().isEnabled()).isTrue();
 					assertThat(properties.getCommand().getHelp().isEnabled()).isTrue();
+					assertThat(properties.getCommand().getHelp().getGroupingMode()).isEqualTo(GroupingMode.GROUP);
 					assertThat(properties.getCommand().getHistory().isEnabled()).isTrue();
 					assertThat(properties.getCommand().getQuit().isEnabled()).isTrue();
 					assertThat(properties.getCommand().getScript().isEnabled()).isTrue();
@@ -67,6 +69,7 @@ public class SpringShellPropertiesTests {
 				.withPropertyValues("spring.shell.theme.name=fake")
 				.withPropertyValues("spring.shell.command.clear.enabled=false")
 				.withPropertyValues("spring.shell.command.help.enabled=false")
+				.withPropertyValues("spring.shell.command.help.grouping-mode=flat")
 				.withPropertyValues("spring.shell.command.history.enabled=false")
 				.withPropertyValues("spring.shell.command.quit.enabled=false")
 				.withPropertyValues("spring.shell.command.script.enabled=false")
@@ -93,6 +96,7 @@ public class SpringShellPropertiesTests {
 					assertThat(properties.getTheme().getName()).isEqualTo("fake");
 					assertThat(properties.getCommand().getClear().isEnabled()).isFalse();
 					assertThat(properties.getCommand().getHelp().isEnabled()).isFalse();
+					assertThat(properties.getCommand().getHelp().getGroupingMode()).isEqualTo(GroupingMode.FLAT);
 					assertThat(properties.getCommand().getHistory().isEnabled()).isFalse();
 					assertThat(properties.getCommand().getQuit().isEnabled()).isFalse();
 					assertThat(properties.getCommand().getScript().isEnabled()).isFalse();

--- a/spring-shell-autoconfigure/src/test/java/org/springframework/shell/boot/StandardCommandsAutoConfigurationTests.java
+++ b/spring-shell-autoconfigure/src/test/java/org/springframework/shell/boot/StandardCommandsAutoConfigurationTests.java
@@ -15,6 +15,7 @@
  */
 package org.springframework.shell.boot;
 
+import java.lang.reflect.Field;
 import java.util.function.Function;
 
 import org.junit.jupiter.api.Test;
@@ -22,6 +23,8 @@ import org.junit.jupiter.api.Test;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.shell.standard.commands.Completion;
+import org.springframework.shell.standard.commands.Help;
+import org.springframework.util.ReflectionUtils;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -46,6 +49,21 @@ public class StandardCommandsAutoConfigurationTests {
 				.withPropertyValues("spring.shell.command.completion.root-command=fake")
 				.run((context) -> {assertThat(context).hasSingleBean(Completion.class);
 		});
+	}
+
+	@Test
+	public void testHelpCommand() {
+		this.contextRunner
+				.with(disableCommands("clear", "quit", "stacktrace", "script", "history", "completion"))
+				.withPropertyValues("spring.shell.command.help.grouping-mode=flat")
+				.run(context -> {
+					assertThat(context).hasSingleBean(Help.class);
+					Help help = context.getBean(Help.class);
+					Field showGroupsField = ReflectionUtils.findField(Help.class, "showGroups");
+					ReflectionUtils.makeAccessible(showGroupsField);
+					ReflectionUtils.getField(showGroupsField, help);
+					assertThat(ReflectionUtils.getField(showGroupsField, help)).isEqualTo(false);
+				});
 	}
 
 	private static Function<ApplicationContextRunner, ApplicationContextRunner> disableCommands(String... commands) {


### PR DESCRIPTION
- New option spring.shell.command.help.grouping-mode which can be either flat/group.
- Build-in help command can now choose if to group command or just show flat list.
- Fixes #347