### PR TITLE
Add dynamic command registration

### DIFF
--- a/spring-shell-core/src/main/java/org/springframework/shell/CommandRegistry.java
+++ b/spring-shell-core/src/main/java/org/springframework/shell/CommandRegistry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015 the original author or authors.
+ * Copyright 2015-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +13,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package org.springframework.shell;
 
 import java.util.Map;
@@ -23,13 +22,27 @@ import java.util.Map;
  * discover available commands.
  *
  * @author Eric Bottard
+ * @author Janne Valkealahti
  */
 public interface CommandRegistry {
-
 
 	/**
 	 * Return the mapping from command trigger keywords to implementation.
 	 */
-	public Map<String, MethodTarget> listCommands();
+	Map<String, MethodTarget> listCommands();
 
+	/**
+	 * Register a new command.
+	 *
+	 * @param name the command name
+	 * @param target the method target
+	 */
+	void addCommand(String name, MethodTarget target);
+
+	/**
+	 * Deregister a command.
+	 *
+	 * @param name the command name
+	 */
+	void removeCommand(String name);
 }

--- a/spring-shell-core/src/main/java/org/springframework/shell/ConfigurableCommandRegistry.java
+++ b/spring-shell-core/src/main/java/org/springframework/shell/ConfigurableCommandRegistry.java
@@ -58,6 +58,16 @@ public class ConfigurableCommandRegistry implements CommandRegistry {
 				.collect(Collectors.toMap(e -> e.getKey(), e -> e.getValue()));
 	}
 
+	@Override
+	public void addCommand(String name, MethodTarget target) {
+		commands.put(name, target);
+	}
+
+	@Override
+	public void removeCommand(String name) {
+		commands.remove(name);
+	}
+
 	public void register(String name, MethodTarget target) {
 		MethodTarget previous = commands.get(name);
 		if (previous != null) {

--- a/spring-shell-core/src/main/java/org/springframework/shell/MethodTarget.java
+++ b/spring-shell-core/src/main/java/org/springframework/shell/MethodTarget.java
@@ -72,6 +72,14 @@ public class MethodTarget implements Command {
 	 * Construct a MethodTarget for the unique method named {@literal name} on the given object. Fails with an exception
 	 * in case of overloaded method.
 	 */
+	public static MethodTarget of(String name, Object bean, String description, String group) {
+		return of(name, bean, new Help(description, group));
+	}
+
+	/**
+	 * Construct a MethodTarget for the unique method named {@literal name} on the given object. Fails with an exception
+	 * in case of overloaded method.
+	 */
 	public static MethodTarget of(String name, Object bean, Help help) {
 		return of(name, bean, help, null);
 	}

--- a/spring-shell-samples/src/main/java/org/springframework/shell/samples/standard/RegisterCommands.java
+++ b/spring-shell-samples/src/main/java/org/springframework/shell/samples/standard/RegisterCommands.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.shell.samples.standard;
+
+import org.springframework.shell.MethodTarget;
+import org.springframework.shell.standard.AbstractShellComponent;
+import org.springframework.shell.standard.ShellComponent;
+import org.springframework.shell.standard.ShellMethod;
+import org.springframework.shell.standard.ShellOption;
+
+@ShellComponent
+public class RegisterCommands extends AbstractShellComponent {
+
+	private final PojoMethods pojoMethods = new PojoMethods();
+
+    @ShellMethod(key = "register add", value = "Register commands", group = "Register Commands")
+    public String register() {
+		MethodTarget target1 = MethodTarget.of("dynamic1", pojoMethods, "Dynamic1 command", "Register Commands");
+		MethodTarget target2 = MethodTarget.of("dynamic2", pojoMethods, "Dynamic2 command", "Register Commands");
+		MethodTarget target3 = MethodTarget.of("dynamic3", pojoMethods, "Dynamic3 command", "Register Commands");
+		getCommandRegistry().addCommand("register dynamic1", target1);
+		getCommandRegistry().addCommand("register dynamic2", target2);
+		getCommandRegistry().addCommand("register dynamic3", target3);
+		return "Registered commands dynamic1, dynamic2, dynamic3";
+    }
+
+    @ShellMethod(key = "register remove", value = "Deregister commands", group = "Register Commands")
+    public String deregister() {
+		getCommandRegistry().removeCommand("register dynamic1");
+		getCommandRegistry().removeCommand("register dynamic2");
+		getCommandRegistry().removeCommand("register dynamic3");
+		return "Deregistered commands dynamic1, dynamic2, dynamic3";
+    }
+
+	public static class PojoMethods {
+
+		@ShellMethod
+		public String dynamic1() {
+			return "dynamic1";
+		}
+
+		@ShellMethod
+		public String dynamic2(String arg1) {
+			return "dynamic2" + arg1;
+		}
+
+		@ShellMethod
+		public String dynamic3(@ShellOption(defaultValue = ShellOption.NULL) String arg1) {
+			return "dynamic3" + arg1;
+		}
+	}
+}

--- a/spring-shell-standard-commands/src/test/java/org/springframework/shell/standard/commands/HelpTest.java
+++ b/spring-shell-standard-commands/src/test/java/org/springframework/shell/standard/commands/HelpTest.java
@@ -123,26 +123,39 @@ public class HelpTest {
 
 		@Bean
 		public CommandRegistry shell() {
-			return () -> {
-				Map<String, MethodTarget> result = new HashMap<>();
-				MethodTarget methodTarget = MethodTarget.of("firstCommand", commands(), new Command.Help("A rather extensive description of some command."));
-				result.put("first-command", methodTarget);
-				result.put("1st-command", methodTarget);
 
-				methodTarget = MethodTarget.of("secondCommand", commands(), new Command.Help("The second command. This one is known under several aliases as well."));
-				result.put("second-command", methodTarget);
-				result.put("yet-another-command", methodTarget);
+			return new CommandRegistry() {
 
-				methodTarget = MethodTarget.of("thirdCommand", commands(), new Command.Help("The last command."));
-				result.put("third-command", methodTarget);
+				@Override
+				public Map<String, MethodTarget> listCommands() {
+					Map<String, MethodTarget> result = new HashMap<>();
+					MethodTarget methodTarget = MethodTarget.of("firstCommand", commands(), new Command.Help("A rather extensive description of some command."));
+					result.put("first-command", methodTarget);
+					result.put("1st-command", methodTarget);
 
-				methodTarget = MethodTarget.of("firstCommandInGroup", commands(), new Command.Help("The first command in a separate group.", "Example Group"));
-				result.put("first-group-command", methodTarget);
+					methodTarget = MethodTarget.of("secondCommand", commands(), new Command.Help("The second command. This one is known under several aliases as well."));
+					result.put("second-command", methodTarget);
+					result.put("yet-another-command", methodTarget);
 
-				methodTarget = MethodTarget.of("secondCommandInGroup", commands(), new Command.Help("The second command in a separate group.", "Example Group"));
-				result.put("second-group-command", methodTarget);
+					methodTarget = MethodTarget.of("thirdCommand", commands(), new Command.Help("The last command."));
+					result.put("third-command", methodTarget);
 
-				return result;
+					methodTarget = MethodTarget.of("firstCommandInGroup", commands(), new Command.Help("The first command in a separate group.", "Example Group"));
+					result.put("first-group-command", methodTarget);
+
+					methodTarget = MethodTarget.of("secondCommandInGroup", commands(), new Command.Help("The second command in a separate group.", "Example Group"));
+					result.put("second-group-command", methodTarget);
+
+					return result;
+				}
+
+				@Override
+				public void addCommand(String name, MethodTarget target) {
+				}
+
+				@Override
+				public void removeCommand(String name) {
+				}
 			};
 		}
 


### PR DESCRIPTION
- Extend CommandRegistry for add/remove methods.
- For rest of shell classes move to use registry
  directly instead of caching commands as registry
  is not immutable anymore.
- Add new sample
- Fixes #379