### PR TITLE
Fix ConversionService in auto-config

### DIFF
--- a/spring-shell-autoconfigure/src/main/java/org/springframework/shell/boot/ParameterResolverAutoConfiguration.java
+++ b/spring-shell-autoconfigure/src/main/java/org/springframework/shell/boot/ParameterResolverAutoConfiguration.java
@@ -3,9 +3,10 @@ package org.springframework.shell.boot;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.core.convert.support.DefaultConversionService;
+import org.springframework.core.convert.ConversionService;
 import org.springframework.messaging.handler.annotation.support.HeadersMethodArgumentResolver;
 import org.springframework.messaging.handler.invocation.HandlerMethodArgumentResolver;
 import org.springframework.shell.command.ArgumentHeaderMethodArgumentResolver;
@@ -24,12 +25,13 @@ public class ParameterResolverAutoConfiguration {
 	}
 
 	@Bean
-	public CommandExecutionHandlerMethodArgumentResolvers commandExecutionHandlerMethodArgumentResolvers() {
+	public CommandExecutionHandlerMethodArgumentResolvers commandExecutionHandlerMethodArgumentResolvers(
+			@Qualifier("shellConversionService") ConversionService shellConversionService) {
 		List<HandlerMethodArgumentResolver> resolvers = new ArrayList<>();
-		resolvers.add(new ArgumentHeaderMethodArgumentResolver(new DefaultConversionService(), null));
+		resolvers.add(new ArgumentHeaderMethodArgumentResolver(shellConversionService, null));
 		resolvers.add(new HeadersMethodArgumentResolver());
 		resolvers.add(new CommandContextMethodArgumentResolver());
-		resolvers.add(new ShellOptionMethodArgumentResolver(new DefaultConversionService(), null));
+		resolvers.add(new ShellOptionMethodArgumentResolver(shellConversionService, null));
 		return new CommandExecutionHandlerMethodArgumentResolvers(resolvers);
 	}
 }

--- a/spring-shell-autoconfigure/src/test/java/org/springframework/shell/boot/ParameterResolverAutoConfigurationTests.java
+++ b/spring-shell-autoconfigure/src/test/java/org/springframework/shell/boot/ParameterResolverAutoConfigurationTests.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.shell.boot;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.convert.ConversionService;
+import org.springframework.core.convert.support.DefaultConversionService;
+import org.springframework.shell.command.CommandExecution.CommandExecutionHandlerMethodArgumentResolvers;
+import org.springframework.shell.completion.CompletionResolver;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ParameterResolverAutoConfigurationTests {
+
+	private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+			.withConfiguration(AutoConfigurations.of(ParameterResolverAutoConfiguration.class));
+
+	@Test
+	void defaultCompletionResolverExists() {
+		this.contextRunner.withUserConfiguration(CustomShellConversionServiceConfiguration.class)
+				.run((context) -> {
+					assertThat(context).hasSingleBean(CompletionResolver.class);
+				});
+	}
+
+	@Test
+	void defaultCommandExecutionHandlerMethodArgumentResolversExists() {
+		this.contextRunner.withUserConfiguration(CustomShellConversionServiceConfiguration.class)
+				.run((context) -> {
+					assertThat(context).hasSingleBean(CommandExecutionHandlerMethodArgumentResolvers.class);
+				});
+	}
+
+	@Test
+	void multipleConversionServiceBeans() {
+		this.contextRunner
+				.withUserConfiguration(CustomShellConversionServiceConfiguration.class,
+						ExtraConversionServiceConfiguration.class)
+				.run((context) -> {
+					assertThat(context).hasSingleBean(CommandExecutionHandlerMethodArgumentResolvers.class);
+				});
+	}
+
+	@Configuration
+	static class CustomShellConversionServiceConfiguration {
+
+		@Bean
+		ConversionService shellConversionService() {
+			return new DefaultConversionService();
+		}
+	}
+
+	@Configuration
+	static class ExtraConversionServiceConfiguration {
+
+		@Bean
+		ConversionService conversionService() {
+			return new DefaultConversionService();
+		}
+	}
+}


### PR DESCRIPTION
- Now using qualifier for one we expect which should
  work if some other services are in a context.
- Properly use shellConversionService in defined
  MethodArgumentResolver beans.
- Fixes #400