### PR TITLE
Allow Shell.input() to be overridden in subclasses

### DIFF
--- a/spring-shell-core/src/main/java/org/springframework/shell/Shell.java
+++ b/spring-shell-core/src/main/java/org/springframework/shell/Shell.java
@@ -190,7 +190,7 @@ public class Shell {
 	 * result
 	 * </p>
 	 */
-	private Object evaluate(Input input) {
+	protected Object evaluate(Input input) {
 		if (noInput(input)) {
 			return NO_INPUT;
 		}


### PR DESCRIPTION
Hi,

can we set `Shell.input()` to `protected`, so it can be overriden by other projects?

In https://github.com/fonimus/ssh-shell-spring-boot is a class [ExtendedShell.java](https://github.com/fonimus/ssh-shell-spring-boot/blob/main/starter/src/main/java/com/github/fonimus/ssh/shell/ExtendedShell.java#L110) which needs to override and also access the input()-Method to inject input received via the SSH session properly.

Thanks,
     Chris