### PR TITLE
Replace deprecated command with environment file

### DIFF
--- a/.github/workflows/release-ga.yml
+++ b/.github/workflows/release-ga.yml
@@ -65,7 +65,7 @@ jobs:
       env:
         PROJECT_VERSION: ${{ env.PROJECT_VERSION }}
       run: |
-        echo "::set-output name=project-version::$PROJECT_VERSION"
+        echo "project-version=$PROJECT_VERSION" >> $GITHUB_OUTPUT
 
   promote:
     runs-on: ubuntu-latest

--- a/.github/workflows/release-milestone.yml
+++ b/.github/workflows/release-milestone.yml
@@ -70,7 +70,7 @@ jobs:
       env:
         PROJECT_VERSION: ${{ env.PROJECT_VERSION }}
       run: |
-        echo "::set-output name=project-version::$PROJECT_VERSION"
+        echo "project-version=$PROJECT_VERSION" >> $GITHUB_OUTPUT
 
   promote:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Signed-off-by: jongwooo <jongwooo.han@gmail.com>

## Description

Resolve  #657 

Update workflows to use environment file instead of deprecated `set-output` command. 
For more information, see: [https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)

I found the workflow files that use `set-output` command through the following command:

```bash
$ find .github/workflows -name '*.yml' | xargs egrep '\bset-output\b'
```

**AS-IS**

```yml
run: |
  echo "::set-output name=project-version::$PROJECT_VERSION"
```

**TO-BE**

```yml
run: |
  echo "project-version=$PROJECT_VERSION" >> $GITHUB_OUTPUT
```
