### PR TITLE
Rename setMaskCharater to setMaskCharacter

### DIFF
--- a/spring-shell-core/src/main/java/org/springframework/shell/component/StringInput.java
+++ b/spring-shell-core/src/main/java/org/springframework/shell/component/StringInput.java
@@ -66,7 +66,7 @@ public class StringInput extends AbstractTextComponent<String, StringInputContex
 	 *
 	 * @param maskCharacter a mask character
 	 */
-	public void setMaskCharater(Character maskCharacter) {
+	public void setMaskCharacter(Character maskCharacter) {
 		this.maskCharacter = maskCharacter;
 	}
 

--- a/spring-shell-core/src/main/java/org/springframework/shell/component/flow/ComponentFlow.java
+++ b/spring-shell-core/src/main/java/org/springframework/shell/component/flow/ComponentFlow.java
@@ -454,7 +454,7 @@ public interface ComponentFlow {
 						}
 						selector.setResourceLoader(resourceLoader);
 						selector.setTemplateExecutor(templateExecutor);
-						selector.setMaskCharater(input.getMaskCharacter());
+						selector.setMaskCharacter(input.getMaskCharacter());
 						if (StringUtils.hasText(input.getTemplateLocation())) {
 							selector.setTemplateLocation(input.getTemplateLocation());
 						}

--- a/spring-shell-core/src/test/java/org/springframework/shell/component/StringInputTests.java
+++ b/spring-shell-core/src/test/java/org/springframework/shell/component/StringInputTests.java
@@ -122,7 +122,7 @@ public class StringInputTests extends AbstractShellTests {
 		ComponentContext<?> empty = ComponentContext.empty();
 		StringInput component1 = new StringInput(getTerminal(), "component1", "component1ResultValue");
 		component1.setPrintResults(true);
-		component1.setMaskCharater('*');
+		component1.setMaskCharacter('*');
 		component1.setResourceLoader(new DefaultResourceLoader());
 		component1.setTemplateExecutor(getTemplateExecutor());
 

--- a/spring-shell-docs/src/test/java/org/springframework/shell/docs/UiComponentSnippets.java
+++ b/spring-shell-docs/src/test/java/org/springframework/shell/docs/UiComponentSnippets.java
@@ -79,7 +79,7 @@ public class UiComponentSnippets {
 			component.setResourceLoader(getResourceLoader());
 			component.setTemplateExecutor(getTemplateExecutor());
 			if (mask) {
-				component.setMaskCharater('*');
+				component.setMaskCharacter('*');
 			}
 			StringInputContext context = component.run(StringInputContext.empty());
 			return "Got value " + context.getResultValue();
@@ -98,7 +98,7 @@ public class UiComponentSnippets {
 				component.setResourceLoader(getResourceLoader());
 				component.setTemplateExecutor(getTemplateExecutor());
 				if (mask) {
-					component.setMaskCharater('*');
+					component.setMaskCharacter('*');
 				}
 				StringInputContext context = component.run(StringInputContext.empty());
 				return "Got value " + context.getResultValue();

--- a/spring-shell-samples/src/main/java/org/springframework/shell/samples/standard/ComponentCommands.java
+++ b/spring-shell-samples/src/main/java/org/springframework/shell/samples/standard/ComponentCommands.java
@@ -54,7 +54,7 @@ public class ComponentCommands extends AbstractShellComponent {
 		component.setResourceLoader(getResourceLoader());
 		component.setTemplateExecutor(getTemplateExecutor());
 		if (mask) {
-			component.setMaskCharater('*');
+			component.setMaskCharacter('*');
 		}
 		StringInputContext context = component.run(StringInputContext.empty());
 		return "Got value " + context.getResultValue();
@@ -155,7 +155,7 @@ public class ComponentCommands extends AbstractShellComponent {
 		component.setResourceLoader(getResourceLoader());
 		component.setTemplateExecutor(getTemplateExecutor());
 		if (mask) {
-			component.setMaskCharater('*');
+			component.setMaskCharacter('*');
 		}
 		StringInputContext context = component.run(StringInputContext.empty());
 		return "Got value " + context.getResultValue();


### PR DESCRIPTION
Currently, spring-shell-core/src/main/java/org/springframework/shell/component/StringInput.java contains the former, which is likely a typographical error? Resolves #686 