### PR TITLE
Pass ShellContext to CommandCatalog.of in CommandCatalogAutoConfig

### DIFF
--- a/spring-shell-autoconfigure/src/main/java/org/springframework/shell/boot/CommandCatalogAutoConfiguration.java
+++ b/spring-shell-autoconfigure/src/main/java/org/springframework/shell/boot/CommandCatalogAutoConfiguration.java
@@ -34,6 +34,7 @@ import org.springframework.shell.command.CommandRegistration.BuilderSupplier;
 import org.springframework.shell.command.CommandRegistration.OptionNameModifier;
 import org.springframework.shell.command.support.OptionNameModifierSupport;
 import org.springframework.shell.command.CommandResolver;
+import org.springframework.shell.context.ShellContext;
 
 @AutoConfiguration
 @EnableConfigurationProperties(SpringShellProperties.class)
@@ -43,9 +44,10 @@ public class CommandCatalogAutoConfiguration {
 	@ConditionalOnMissingBean(CommandCatalog.class)
 	public CommandCatalog commandCatalog(ObjectProvider<MethodTargetRegistrar> methodTargetRegistrars,
 			ObjectProvider<CommandResolver> commandResolvers,
-			ObjectProvider<CommandCatalogCustomizer> commandCatalogCustomizers) {
+			ObjectProvider<CommandCatalogCustomizer> commandCatalogCustomizers,
+			ShellContext shellContext) {
 		List<CommandResolver> resolvers = commandResolvers.orderedStream().collect(Collectors.toList());
-		CommandCatalog catalog = CommandCatalog.of(resolvers, null);
+		CommandCatalog catalog = CommandCatalog.of(resolvers, shellContext);
 		methodTargetRegistrars.orderedStream().forEach(resolver -> {
 			resolver.register(catalog);
 		});

--- a/spring-shell-autoconfigure/src/test/java/org/springframework/shell/boot/CommandCatalogAutoConfigurationTests.java
+++ b/spring-shell-autoconfigure/src/test/java/org/springframework/shell/boot/CommandCatalogAutoConfigurationTests.java
@@ -36,7 +36,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class CommandCatalogAutoConfigurationTests {
 
 	private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
-			.withConfiguration(AutoConfigurations.of(CommandCatalogAutoConfiguration.class));
+			.withConfiguration(AutoConfigurations.of(CommandCatalogAutoConfiguration.class, ShellContextAutoConfiguration.class));
 
 	@Test
 	void defaultCommandCatalog() {


### PR DESCRIPTION
## Pass ShellContext to CommandCatalog.of in CommandCatalogAutoConfiguration

A Small Bugfix. The `ShellContext` is not passed to `CommandCatalog.of` in `CommandCatalogAutoConfiguration`. As a consequence, command filtering by interaction mode is not working as expected.