### PR TITLE
Option for auto-completing single argument without spaces insertion (complete support)

### DIFF
--- a/spring-shell-autoconfigure/src/main/java/org/springframework/shell/boot/CompleterAutoConfiguration.java
+++ b/spring-shell-autoconfigure/src/main/java/org/springframework/shell/boot/CompleterAutoConfiguration.java
@@ -63,7 +63,7 @@ public class CompleterAutoConfiguration {
 					p.description(),
 					null,
 					null,
-					true)
+					p.complete())
 				)
 				.forEach(candidates::add);
 		}

--- a/spring-shell-core/src/main/java/org/springframework/shell/CompletionProposal.java
+++ b/spring-shell-core/src/main/java/org/springframework/shell/CompletionProposal.java
@@ -49,6 +49,12 @@ public class CompletionProposal {
 	 */
 	private boolean dontQuote = false;
 
+	/**
+	 * Whether the proposal cant be completed further. By setting complete to false then it will not append an space
+	 * making it easier to continue tab completion
+	 */
+	private boolean complete = true;
+
 	public CompletionProposal(String value) {
 		this.value = this.displayText = value;
 	}
@@ -88,6 +94,16 @@ public class CompletionProposal {
 		this.category = category;
 		return this;
 	}
+
+	public CompletionProposal complete(boolean complete) {
+		this.complete = complete;
+		return this;
+	}
+
+	public boolean complete() {
+		return complete;
+	}
+
 
 	public CompletionProposal dontQuote(boolean dontQuote) {
 		this.dontQuote = dontQuote;

--- a/spring-shell-standard/src/main/java/org/springframework/shell/standard/FileValueProvider.java
+++ b/spring-shell-standard/src/main/java/org/springframework/shell/standard/FileValueProvider.java
@@ -16,6 +16,9 @@
 
 package org.springframework.shell.standard;
 
+import org.springframework.shell.CompletionContext;
+import org.springframework.shell.CompletionProposal;
+
 import java.io.File;
 import java.io.IOException;
 import java.io.UncheckedIOException;
@@ -24,9 +27,6 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
 import java.util.stream.Collectors;
-
-import org.springframework.shell.CompletionContext;
-import org.springframework.shell.CompletionProposal;
 
 import static java.nio.file.FileVisitOption.FOLLOW_LINKS;
 
@@ -39,21 +39,25 @@ import static java.nio.file.FileVisitOption.FOLLOW_LINKS;
  */
 public class FileValueProvider implements ValueProvider {
 
-	@Override
-	public List<CompletionProposal> complete(CompletionContext completionContext) {
+    @Override
+    public List<CompletionProposal> complete(CompletionContext completionContext) {
         String input = completionContext.currentWordUpToCursor();
         int lastSlash = input.lastIndexOf(File.separatorChar);
-        Path dir = lastSlash > -1 ? Paths.get(input.substring(0, lastSlash+1)) : Paths.get("");
-        String prefix = input.substring(lastSlash + 1, input.length());
+        Path dir = lastSlash > -1 ? Paths.get(input.substring(0, lastSlash + 1)) : Paths.get("");
+        String prefix = input.substring(lastSlash + 1);
 
         try {
             return Files
-                    .find(dir, 1, (p, a) -> p.getFileName() != null && p.getFileName().toString().startsWith(prefix),
-                            FOLLOW_LINKS)
-                    .map(p -> new CompletionProposal(p.toString()))
-                    .collect(Collectors.toList());
+                .find(dir, 1, (p, a) -> p.getFileName() != null && p.getFileName().toString().startsWith(prefix),
+                    FOLLOW_LINKS)
+                .map(p -> {
+                    boolean directory = Files.isDirectory(p);
+                    String value = p.toString() + (directory ? File.separatorChar : "");
+                    return new CompletionProposal(value).complete(!directory);
+                })
+                .collect(Collectors.toList());
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }
-	}
+    }
 }


### PR DESCRIPTION
Support for completing  single argument with multiple tab clicks. For example file paths.

I've also adjusted the File completion to add a separator when completion reaches directory. Then mark as complete when reaches a file.

I quickly looked and could not find related test cases to add this scenarios. 

Related issues:
https://github.com/spring-projects/spring-shell/issues/285
https://github.com/spring-projects/spring-shell/issues/512
