### PR TITLE
Do not include timestamp for buildInfo.

### DIFF
--- a/spring-shell-samples/spring-shell-sample-catalog/spring-shell-sample-catalog.gradle
+++ b/spring-shell-samples/spring-shell-sample-catalog/spring-shell-sample-catalog.gradle
@@ -15,7 +15,9 @@ dependencies {
 }
 
 springBoot {
-	buildInfo()
+    buildInfo {
+        excludes = ['time']
+    }
 }
 
 if (project.hasProperty('springShellSampleE2E') && springShellSampleE2E.toBoolean()) {

--- a/spring-shell-samples/spring-shell-sample-commands/spring-shell-sample-commands.gradle
+++ b/spring-shell-samples/spring-shell-sample-commands/spring-shell-sample-commands.gradle
@@ -15,7 +15,9 @@ dependencies {
 }
 
 springBoot {
-	buildInfo()
+    buildInfo {
+        excludes = ['time']
+    }
 }
 
 if (project.hasProperty('springShellSampleE2E') && springShellSampleE2E.toBoolean()) {

--- a/spring-shell-samples/spring-shell-sample-e2e/spring-shell-sample-e2e.gradle
+++ b/spring-shell-samples/spring-shell-sample-e2e/spring-shell-sample-e2e.gradle
@@ -15,7 +15,9 @@ dependencies {
 }
 
 springBoot {
-	buildInfo()
+    buildInfo {
+        excludes = ['time']
+    }
 }
 
 if (project.hasProperty('springShellSampleE2E') && springShellSampleE2E.toBoolean()) {


### PR DESCRIPTION
## Description
Addresses a build issue where the build information being generated on each build includes a timestamp. Since the timestamp is incremented each time, no incremental builds will take place for those that tasks that depend on this `buildInfo` task.

### Performance Before Changes Applied
The build scan can be seen here with performance details, with a overall time for executing tasks of 45.650s: 
https://scans.gradle.com/s/vgim65zsvbrzm/performance/execution#wall-clock-time

### Performance After Changes Applied
Without timestamps being put in the build info, the overall time for executing tasks was 14.763 seconds:  
https://scans.gradle.com/s/p5ldndkjxwy4g/performance/execution#wall-clock-time

### Some background
The spring boot documentation regarding actually mentions this behavior. Following the link below and looking at the example on excluding the 'time' show the essence of this change.

https://docs.spring.io/spring-boot/docs/current/gradle-plugin/reference/htmlsingle/#integrating-with-actuator.build-info

@pivotal-cla This is an Obvious Fix