### PR TITLE
Use string array in ShellRunner

### DIFF
--- a/spring-shell-core/src/main/java/org/springframework/shell/DefaultShellApplicationRunner.java
+++ b/spring-shell-core/src/main/java/org/springframework/shell/DefaultShellApplicationRunner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2022 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -56,6 +56,27 @@ public class DefaultShellApplicationRunner implements ShellApplicationRunner {
 	@Override
 	public void run(ApplicationArguments args) throws Exception {
 		log.debug("Checking shell runners {}", shellRunners);
+
+		// Handle new ShellRunner api
+		String[] sourceArgs = args.getSourceArgs();
+		boolean canRun = false;
+		for (ShellRunner runner : shellRunners) {
+			try {
+				canRun = runner.run(sourceArgs);
+			} catch (Exception e) {
+				break;
+			}
+			if (canRun) {
+				break;
+			}
+		}
+
+		if (canRun) {
+			// new api handled execution
+			return;
+		}
+
+		// Handle old deprecated ShellRunner api
 		Optional<ShellRunner> optional = shellRunners.stream()
 				.filter(sh -> sh.canRun(args))
 				.findFirst();

--- a/spring-shell-core/src/main/java/org/springframework/shell/ShellRunner.java
+++ b/spring-shell-core/src/main/java/org/springframework/shell/ShellRunner.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 the original author or authors.
+ * Copyright 2021-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,16 +27,41 @@ public interface ShellRunner {
 	/**
 	 * Checks if a particular shell runner can execute.
 	 *
+	 * For {@link #canRun(ApplicationArguments)} and
+	 * {@link #run(ApplicationArguments)} prefer {@link #run(String[])}.
+	 *
 	 * @param args the application arguments
 	 * @return true if shell runner can execute
 	 */
-	boolean canRun(ApplicationArguments args);
+	@Deprecated(since = "3.3.0", forRemoval = true)
+	default boolean canRun(ApplicationArguments args) {
+		return false;
+	}
 
 	/**
 	 * Execute application.
 	 *
+	 * For {@link #canRun(ApplicationArguments)} and
+	 * {@link #run(ApplicationArguments)} prefer {@link #run(String[])}.
+	 *
 	 * @param args the application argumets
 	 * @throws Exception in errors
 	 */
-	void run(ApplicationArguments args) throws Exception;
+	@Deprecated(since = "3.3.0", forRemoval = true)
+	default void run(ApplicationArguments args) throws Exception {
+		throw new UnsupportedOperationException("Should get implemented together with canRun");
+	}
+
+	/**
+	 * Execute {@code ShellRunner} with given args. Return value indicates if run
+	 * operation happened and no further runners should be used.
+	 *
+	 * @param args the raw arguments
+	 * @return true if run execution happened
+	 * @throws Exception possible error during run
+	 */
+	default boolean run(String[] args) throws Exception {
+		return false;
+	}
+
 }

--- a/spring-shell-core/src/main/java/org/springframework/shell/jline/InteractiveShellRunner.java
+++ b/spring-shell-core/src/main/java/org/springframework/shell/jline/InteractiveShellRunner.java
@@ -21,7 +21,6 @@ import org.jline.reader.LineReader;
 import org.jline.reader.UserInterruptException;
 import org.jline.utils.AttributedString;
 
-import org.springframework.boot.ApplicationArguments;
 import org.springframework.core.annotation.Order;
 import org.springframework.shell.ExitRequest;
 import org.springframework.shell.Input;
@@ -67,14 +66,10 @@ public class InteractiveShellRunner implements ShellRunner {
 	}
 
 	@Override
-	public void run(ApplicationArguments args) throws Exception {
+	public boolean run(String[] args) throws Exception {
 		shellContext.setInteractionMode(InteractionMode.INTERACTIVE);
 		InputProvider inputProvider = new JLineInputProvider(lineReader, promptProvider);
 		shell.run(inputProvider);
-	}
-
-	@Override
-	public boolean canRun(ApplicationArguments args) {
 		return true;
 	}
 

--- a/spring-shell-core/src/main/java/org/springframework/shell/jline/ScriptShellRunner.java
+++ b/spring-shell-core/src/main/java/org/springframework/shell/jline/ScriptShellRunner.java
@@ -19,15 +19,16 @@ package org.springframework.shell.jline;
 import java.io.File;
 import java.io.FileReader;
 import java.io.Reader;
+import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 
 import org.jline.reader.Parser;
 
-import org.springframework.boot.ApplicationArguments;
 import org.springframework.core.annotation.Order;
 import org.springframework.shell.Shell;
 import org.springframework.shell.ShellRunner;
+import org.springframework.util.ObjectUtils;
 
 /**
  * A {@link ShellRunner} that looks for process arguments that start with {@literal @}, which are then interpreted as
@@ -59,19 +60,16 @@ public class ScriptShellRunner implements ShellRunner {
 	}
 
 	@Override
-	public boolean canRun(ApplicationArguments args) {
-		String[] sourceArgs = args.getSourceArgs();
-		if (sourceArgs.length > 0 && sourceArgs[0].startsWith("@") && sourceArgs[0].length() > 1) {
-			return true;
+	public boolean run(String[] args) throws Exception {
+		String[] sourceArgs = args;
+		if (ObjectUtils.isEmpty(sourceArgs)) {
+			return false;
 		}
-		return false;
-	}
+		if (!(sourceArgs[0].startsWith("@") && sourceArgs[0].length() > 1)) {
+			return false;
+		}
 
-	//tag::documentation[]
-
-	@Override
-	public void run(ApplicationArguments args) throws Exception {
-		List<File> scriptsToRun = args.getNonOptionArgs().stream()
+		List<File> scriptsToRun = Arrays.asList(args).stream()
 				.filter(s -> s.startsWith("@"))
 				.map(s -> new File(s.substring(1)))
 				.collect(Collectors.toList());
@@ -82,7 +80,8 @@ public class ScriptShellRunner implements ShellRunner {
 				shell.run(inputProvider);
 			}
 		}
+
+		return true;
 	}
-	//end::documentation[]
 
 }

--- a/spring-shell-core/src/test/java/org/springframework/shell/jline/InteractiveShellRunnerTests.java
+++ b/spring-shell-core/src/test/java/org/springframework/shell/jline/InteractiveShellRunnerTests.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.springframework.shell.jline;
 
 import java.io.ByteArrayOutputStream;
@@ -14,6 +29,8 @@ import org.jline.utils.AttributedString;
 import org.jline.utils.AttributedStyle;
 import org.junit.jupiter.api.Test;
 
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.DefaultApplicationArguments;
 import org.springframework.shell.ExitRequest;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -132,4 +149,24 @@ public class InteractiveShellRunnerTests {
         readThread.join();
         writeThread.join();
     }
+
+
+	@Test
+	void oldApiCanRunReturnFalse() {
+        InteractiveShellRunner runner = new InteractiveShellRunner(null, null, null, null);
+		assertThat(runner.canRun(ofApplicationArguments())).isFalse();
+	}
+
+	@Test
+	void oldApiRunThrows() {
+        InteractiveShellRunner runner = new InteractiveShellRunner(null, null, null, null);
+		assertThatThrownBy(() -> {
+			runner.run(ofApplicationArguments());
+		});
+	}
+
+	private static ApplicationArguments ofApplicationArguments(String... args) {
+		return new DefaultApplicationArguments(args);
+	}
+
 }

--- a/spring-shell-test/src/main/java/org/springframework/shell/test/ShellTestClient.java
+++ b/spring-shell-test/src/main/java/org/springframework/shell/test/ShellTestClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 the original author or authors.
+ * Copyright 2022-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -340,7 +340,12 @@ public interface ShellTestClient extends Closeable {
 					try {
 						log.trace("Running {}", data.runner());
 						data.state().set(-1);
-						data.runner().run(data.args());
+						if (data.runner().canRun(data.args)) {
+							data.runner().run(data.args());
+						}
+						else {
+							data.runner().run(data.args().getSourceArgs());
+						}
 						data.state().set(0);
 						log.trace("Running done {}", data.runner());
 					} catch (Exception e) {


### PR DESCRIPTION
- In ShellRunner interface replace use of boot's ApplicationArguments into plain string array.
- Deprecate old methods with some fallbacks to give time for users to do updates.
- NonInteractiveShellRunner contains one breaking change due to its public api to set function doing conversion from ApplicationArguments which was potentially used via customizer hooks.
- Deprecations planned to get removed in 3.4.x.
- Fixes #1057