### PR TITLE
chore: bump spring-shell-e2e dependencies

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -95,10 +95,6 @@ jobs:
           distribution: adopt
           java-version: 21
           cache: gradle
-      - name: Use Python 3.11
-        uses: actions/setup-python@v4
-        with:
-          python-version: '3.11'
       - uses: actions/setup-node@v2
         with:
           node-version: '16'

--- a/e2e/spring-shell-e2e/package-lock.json
+++ b/e2e/spring-shell-e2e/package-lock.json
@@ -9,8 +9,8 @@
       "version": "2.1.0",
       "license": "ISC",
       "dependencies": {
-        "node-pty": "0.11.0-beta19",
-        "xterm-headless": "^4.18.0"
+        "@xterm/headless": "^5.5.0",
+        "node-pty": "^1.0.0"
       },
       "devDependencies": {
         "@types/node": "^18.11.9",
@@ -24,21 +24,23 @@
       "integrity": "sha512-CRpX21/kGdzjOpFsZSkcrXMGIBWMGNIHXXBVFSH+ggkftxg+XYP20TESbh+zFvFj3EQOl5byk0HTRn1IL6hbqg==",
       "dev": true
     },
+    "node_modules/@xterm/headless": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/@xterm/headless/-/headless-5.5.0.tgz",
+      "integrity": "sha512-5xXB7kdQlFBP82ViMJTwwEc3gKCLGKR/eoxQm4zge7GPBl86tCdI0IdPJjoKd8mUSFXz5V7i/25sfsEkP4j46g=="
+    },
     "node_modules/nan": {
-      "version": "2.15.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.15.0.tgz",
-      "integrity": "sha512-8ZtvEnA2c5aYCZYd1cvgdnU6cqwixRoYg70xPLWUws5ORTa/lnw+u4amixRS/Ac5U5mQVgp9pnlSUnbNWFaWZQ=="
+      "version": "2.20.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.20.0.tgz",
+      "integrity": "sha512-bk3gXBZDGILuuo/6sKtr0DQmSThYHLtNCdSdXk9YkxD/jK6X2vmCyyXBBxyqZ4XcnzTyYEAThfX3DCEnLf6igw=="
     },
     "node_modules/node-pty": {
-      "version": "0.11.0-beta19",
-      "resolved": "https://registry.npmjs.org/node-pty/-/node-pty-0.11.0-beta19.tgz",
-      "integrity": "sha512-1cdUx15rCVYEcvOvqNRO4S52vYM9mnFyTAceut+lW8/+YWcYQl1TQ3naDqtWHDcVjZI/FbDX1j4iQFwypmJSLQ==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-pty/-/node-pty-1.0.0.tgz",
+      "integrity": "sha512-wtBMWWS7dFZm/VgqElrTvtfMq4GzJ6+edFI0Y0zyzygUSZMgZdraDUMUhCIvkjhJjme15qWmbyJbtAx4ot4uZA==",
       "hasInstallScript": true,
       "dependencies": {
-        "nan": "^2.14.0"
-      },
-      "peerDependencies": {
-        "node-gyp": "^8.3.0"
+        "nan": "^2.17.0"
       }
     },
     "node_modules/prettier": {
@@ -68,11 +70,6 @@
       "engines": {
         "node": ">=4.2.0"
       }
-    },
-    "node_modules/xterm-headless": {
-      "version": "4.18.0",
-      "resolved": "https://registry.npmjs.org/xterm-headless/-/xterm-headless-4.18.0.tgz",
-      "integrity": "sha512-VwSPG2cyVOwesVVLBVrybYNY6cUMiVkD2fLnIXcBs/1iJ3M7bhD3lP9HdQOHGtOkbxV2Duf7MZNmEfngBXL/iQ=="
     }
   },
   "dependencies": {
@@ -82,17 +79,22 @@
       "integrity": "sha512-CRpX21/kGdzjOpFsZSkcrXMGIBWMGNIHXXBVFSH+ggkftxg+XYP20TESbh+zFvFj3EQOl5byk0HTRn1IL6hbqg==",
       "dev": true
     },
+    "@xterm/headless": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/@xterm/headless/-/headless-5.5.0.tgz",
+      "integrity": "sha512-5xXB7kdQlFBP82ViMJTwwEc3gKCLGKR/eoxQm4zge7GPBl86tCdI0IdPJjoKd8mUSFXz5V7i/25sfsEkP4j46g=="
+    },
     "nan": {
-      "version": "2.15.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.15.0.tgz",
-      "integrity": "sha512-8ZtvEnA2c5aYCZYd1cvgdnU6cqwixRoYg70xPLWUws5ORTa/lnw+u4amixRS/Ac5U5mQVgp9pnlSUnbNWFaWZQ=="
+      "version": "2.20.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.20.0.tgz",
+      "integrity": "sha512-bk3gXBZDGILuuo/6sKtr0DQmSThYHLtNCdSdXk9YkxD/jK6X2vmCyyXBBxyqZ4XcnzTyYEAThfX3DCEnLf6igw=="
     },
     "node-pty": {
-      "version": "0.11.0-beta19",
-      "resolved": "https://registry.npmjs.org/node-pty/-/node-pty-0.11.0-beta19.tgz",
-      "integrity": "sha512-1cdUx15rCVYEcvOvqNRO4S52vYM9mnFyTAceut+lW8/+YWcYQl1TQ3naDqtWHDcVjZI/FbDX1j4iQFwypmJSLQ==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-pty/-/node-pty-1.0.0.tgz",
+      "integrity": "sha512-wtBMWWS7dFZm/VgqElrTvtfMq4GzJ6+edFI0Y0zyzygUSZMgZdraDUMUhCIvkjhJjme15qWmbyJbtAx4ot4uZA==",
       "requires": {
-        "nan": "^2.14.0"
+        "nan": "^2.17.0"
       }
     },
     "prettier": {
@@ -106,11 +108,6 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.4.tgz",
       "integrity": "sha512-9ia/jWHIEbo49HfjrLGfKbZSuWo9iTMwXO+Ca3pRsSpbsMbc7/IU8NKdCZVRRBafVPGnoJeFL76ZOAA84I9fEg==",
       "dev": true
-    },
-    "xterm-headless": {
-      "version": "4.18.0",
-      "resolved": "https://registry.npmjs.org/xterm-headless/-/xterm-headless-4.18.0.tgz",
-      "integrity": "sha512-VwSPG2cyVOwesVVLBVrybYNY6cUMiVkD2fLnIXcBs/1iJ3M7bhD3lP9HdQOHGtOkbxV2Duf7MZNmEfngBXL/iQ=="
     }
   }
 }

--- a/e2e/spring-shell-e2e/package.json
+++ b/e2e/spring-shell-e2e/package.json
@@ -36,7 +36,7 @@
     "typescript": "^4.6.4"
   },
   "dependencies": {
-    "node-pty": "0.11.0-beta19",
-    "xterm-headless": "^4.18.0"
+    "node-pty": "^1.0.0",
+    "@xterm/headless": "^5.5.0"
   }
 }


### PR DESCRIPTION
- Bump node-pty from 0.11.0-beta19 to 1.0.0
- Bump xterm-headless from 4.18.0 to 5.5.0
- Rename xterm-headless to @xterm/headless as per https://www.npmjs.com/package/xterm-headless
- Unpin Python 3.11 in e2e test by reverting commit https://github.com/spring-projects/spring-shell/commit/8097f1eb91b6d5bd8e6ff4296e8900d5649a812a because it's no longer necessary as explained in https://github.com/spring-projects/spring-shell/issues/909#issuecomment-2188962147 .

- Fixes https://github.com/spring-projects/spring-shell/issues/909
- Fixes https://github.com/spring-projects/spring-shell/issues/921