### PR TITLE
CommandRegistration.Builder with lambdas

### DIFF
--- a/spring-shell-core/src/main/java/org/springframework/shell/command/CommandRegistration.java
+++ b/spring-shell-core/src/main/java/org/springframework/shell/command/CommandRegistration.java
@@ -751,11 +751,28 @@ public interface CommandRegistration {
 		OptionSpec withOption();
 
 		/**
+		 * Define an option what this command should user for. Can be used multiple
+		 * times.
+		 *
+		 * @param customizer the option spec consumer
+		 * @return option spec for chaining
+		 */
+		Builder withOption(Consumer<OptionSpec> customizer);
+
+		/**
 		 * Define a target what this command should execute
 		 *
 		 * @return target spec for chaining
 		 */
 		TargetSpec withTarget();
+
+		/**
+		 * Define a target what this command should execute
+		 *
+		 * @param customizer the target spec consumer
+		 * @return target spec for chaining
+		 */
+		Builder withTarget(Consumer<TargetSpec> customizer);
 
 		/**
 		 * Define an alias what this command should execute
@@ -765,11 +782,27 @@ public interface CommandRegistration {
 		AliasSpec withAlias();
 
 		/**
+		 * Define an alias what this command should execute
+		 *
+		 * @param customizer the alias spec consumer
+		 * @return alias spec for chaining
+		 */
+		Builder withAlias(Consumer<AliasSpec> customizer);
+
+		/**
 		 * Define an exit code what this command should execute
 		 *
 		 * @return exit code spec for chaining
 		 */
 		ExitCodeSpec withExitCode();
+
+		/**
+		 * Define an exit code what this command should execute
+		 *
+		 * @param customizer the exit code spec consumer
+		 * @return exit code spec for chaining
+		 */
+		Builder withExitCode(Consumer<ExitCodeSpec> customizer);
 
 		/**
 		 * Define an error handling what this command should use
@@ -779,11 +812,27 @@ public interface CommandRegistration {
 		ErrorHandlingSpec withErrorHandling();
 
 		/**
+		 * Define an error handling what this command should use
+		 *
+		 * @param customizer the error handling spec consumer
+		 * @return error handling spec for chaining
+		 */
+		Builder withErrorHandling(Consumer<ErrorHandlingSpec> customizer);
+
+		/**
 		 * Define help options what this command should use.
 		 *
 		 * @return help options spec for chaining
 		 */
 		HelpOptionsSpec withHelpOptions();
+
+		/**
+		 * Define help options what this command should use.
+		 *
+		 * @param customizer the help options spec consumer
+		 * @return help options spec for chaining
+		 */
+		Builder withHelpOptions(Consumer<HelpOptionsSpec> customizer);
 
 		/**
 		 * Builds a {@link CommandRegistration}.
@@ -1408,10 +1457,26 @@ public interface CommandRegistration {
 		}
 
 		@Override
+		public Builder withOption(Consumer<OptionSpec> customizer) {
+			DefaultOptionSpec spec = new DefaultOptionSpec(this);
+			customizer.accept(spec);
+			optionSpecs.add(spec);
+			return this;
+		}
+
+		@Override
 		public TargetSpec withTarget() {
 			DefaultTargetSpec spec = new DefaultTargetSpec(this);
 			targetSpec = spec;
 			return spec;
+		}
+
+		@Override
+		public Builder withTarget(Consumer<TargetSpec> customizer) {
+			DefaultTargetSpec spec = new DefaultTargetSpec(this);
+			customizer.accept(spec);
+			targetSpec = spec;
+			return this;
 		}
 
 		@Override
@@ -1422,10 +1487,26 @@ public interface CommandRegistration {
 		}
 
 		@Override
+		public Builder withAlias(Consumer<AliasSpec> customizer) {
+			DefaultAliasSpec spec = new DefaultAliasSpec(this);
+			customizer.accept(spec);
+			this.aliasSpecs.add(spec);
+			return this;
+		}
+
+		@Override
 		public ExitCodeSpec withExitCode() {
 			DefaultExitCodeSpec spec = new DefaultExitCodeSpec(this);
 			this.exitCodeSpec = spec;
 			return spec;
+		}
+
+		@Override
+		public Builder withExitCode(Consumer<ExitCodeSpec> customizer) {
+			DefaultExitCodeSpec spec = new DefaultExitCodeSpec(this);
+			customizer.accept(spec);
+			this.exitCodeSpec = spec;
+			return this;
 		}
 
 		@Override
@@ -1436,11 +1517,28 @@ public interface CommandRegistration {
 		}
 
 		@Override
+		public Builder withErrorHandling(Consumer<ErrorHandlingSpec> customizer) {
+			DefaultErrorHandlingSpec spec = new DefaultErrorHandlingSpec(this);
+			customizer.accept(spec);
+			this.errorHandlingSpec = spec;
+			return this;
+		}
+
+		@Override
 		public HelpOptionsSpec withHelpOptions() {
 			if (this.helpOptionsSpec == null) {
 				this.helpOptionsSpec = new DefaultHelpOptionsSpec(this);
 			}
 			return this.helpOptionsSpec;
+		}
+
+		@Override
+		public Builder withHelpOptions(Consumer<HelpOptionsSpec> customizer) {
+			if (this.helpOptionsSpec == null) {
+				this.helpOptionsSpec = new DefaultHelpOptionsSpec(this);
+			}
+			customizer.accept(this.helpOptionsSpec);
+			return this;
 		}
 
 		@Override

--- a/spring-shell-samples/spring-shell-sample-commands/src/main/java/org/springframework/shell/samples/standard/FunctionCommands.java
+++ b/spring-shell-samples/spring-shell-sample-commands/src/main/java/org/springframework/shell/samples/standard/FunctionCommands.java
@@ -17,6 +17,7 @@ package org.springframework.shell.samples.standard;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.shell.command.CommandHandlingResult;
 import org.springframework.shell.command.CommandRegistration;
 
 @Configuration
@@ -25,28 +26,28 @@ public class FunctionCommands {
 	@Bean
 	public CommandRegistration commandRegistration1() {
 		return CommandRegistration.builder()
-			.command("function", "command1")
-			.description("function sample")
-			.group("Function Commands")
-			.withTarget()
+				.command("function", "command1")
+				.description("function sample")
+				.group("Function Commands")
+				.withTarget()
 				.function(ctx -> {
 					String arg1 = ctx.getOptionValue("arg1");
 					return String.format("hi, arg1 value is '%s'", arg1);
 				})
 				.and()
-			.withOption()
+				.withOption()
 				.longNames("arg1")
 				.and()
-			.build();
+				.build();
 	}
 
 	@Bean
 	public CommandRegistration commandRegistration2() {
 		return CommandRegistration.builder()
-			.command("function", "command2")
-			.description("function sample")
-			.group("Function Commands")
-			.withTarget()
+				.command("function", "command2")
+				.description("function sample")
+				.group("Function Commands")
+				.withTarget()
 				.function(ctx -> {
 					Boolean a = ctx.getOptionValue("a");
 					Boolean b = ctx.getOptionValue("b");
@@ -54,55 +55,163 @@ public class FunctionCommands {
 					return String.format("hi, boolean values for a, b, c are '%s' '%s' '%s'", a, b, c);
 				})
 				.and()
-			.withOption()
+				.withOption()
 				.shortNames('a')
 				.type(boolean.class)
 				.and()
-			.withOption()
+				.withOption()
 				.shortNames('b')
 				.type(boolean.class)
 				.and()
-			.withOption()
+				.withOption()
 				.shortNames('c')
 				.type(boolean.class)
 				.and()
-			.build();
+				.build();
 	}
 
 	@Bean
 	public CommandRegistration commandRegistration3() {
 		return CommandRegistration.builder()
-			.command("function", "command3")
-			.description("function sample")
-			.group("Function Commands")
-			.withTarget()
+				.command("function", "command3")
+				.description("function sample")
+				.group("Function Commands")
+				.withTarget()
 				.consumer(ctx -> {
 					String arg1 = ctx.getOptionValue("arg1");
 					ctx.getTerminal().writer()
-						.println(String.format("hi, arg1 value is '%s'", arg1));
+							.println(String.format("hi, arg1 value is '%s'", arg1));
 				})
 				.and()
-			.withOption()
+				.withOption()
 				.longNames("arg1")
 				.and()
-			.build();
+				.build();
 	}
 
 	@Bean
 	public CommandRegistration commandRegistration4() {
 		return CommandRegistration.builder()
-			.command("function", "command4")
-			.description("function sample")
-			.group("Function Commands")
-			.withTarget()
+				.command("function", "command4")
+				.description("function sample")
+				.group("Function Commands")
+				.withTarget()
 				.consumer(ctx -> {
 					ctx.getTerminal().writer()
-						.println(String.format("hi, command is '%s'", ctx.getCommandRegistration().getCommand()));
+							.println(String.format("hi, command is '%s'", ctx.getCommandRegistration().getCommand()));
 				})
 				.and()
-			.withOption()
+				.withOption()
 				.longNames("arg1")
 				.and()
-			.build();
+				.build();
+	}
+
+	@Bean
+	public CommandRegistration commandRegistration5() {
+		return CommandRegistration.builder()
+				.command("function", "command5")
+				.description("function sample")
+				.group("Function Commands")
+				.withTarget(targetSpec -> {
+					targetSpec.function(ctx -> {
+						String arg1 = ctx.getOptionValue("arg1");
+						return String.format("hi, arg1 value is '%s'", arg1);
+					});
+				})
+				.withOption(optionSpec -> {
+					optionSpec.longNames("arg1");
+				})
+				.build();
+	}
+
+	@Bean
+	public CommandRegistration commandRegistration6() {
+		return CommandRegistration.builder()
+				.command("function", "command6")
+				.description("function sample")
+				.group("Function Commands")
+				.withTarget(targetSpec -> {
+					targetSpec.function(ctx -> {
+						Boolean a = ctx.getOptionValue("a");
+						Boolean b = ctx.getOptionValue("b");
+						Boolean c = ctx.getOptionValue("c");
+						return String.format("hi, boolean values for a, b, c are '%s' '%s' '%s'", a, b, c);
+					});
+				})
+				.withOption(optionSpec -> {
+					optionSpec.shortNames('a').type(boolean.class);
+				})
+				.withOption(optionSpec -> {
+					optionSpec.shortNames('b').type(boolean.class);
+				})
+				.withOption(optionSpec -> {
+					optionSpec.shortNames('c').type(boolean.class);
+				})
+				.build();
+	}
+
+
+	@Bean
+	public CommandRegistration commandRegistration7() {
+		return CommandRegistration.builder()
+				.command("function", "command7")
+				.description("function sample")
+				.group("Function Commands")
+				.withTarget(targetSpec -> {
+					targetSpec.consumer(ctx -> {
+						String arg1 = ctx.getOptionValue("arg1");
+						ctx.getTerminal().writer()
+								.println(String.format("hi, arg1 value is '%s'", arg1));
+					});
+				})
+				.withOption(optionSpec -> {
+					optionSpec.longNames("arg1");
+				})
+				.build();
+	}
+
+	@Bean
+	public CommandRegistration commandRegistration8() {
+		return CommandRegistration.builder()
+				.command("function", "command8")
+				.description("function sample")
+				.group("Function Commands")
+				.withTarget(targetSpec -> {
+					targetSpec.consumer(ctx -> {
+						ctx.getTerminal().writer()
+								.println(String.format("hi, command is '%s'", ctx.getCommandRegistration().getCommand()));
+					});
+				})
+				.withOption(optionSpec -> {
+					optionSpec.longNames("arg1");
+				})
+				.build();
+	}
+
+	@Bean
+	public CommandRegistration commandRegistration9() {
+		return CommandRegistration.builder()
+				.command("function", "command9")
+				.description("function sample")
+				.group("Function Commands")
+				.withTarget(targetSpec -> {
+					targetSpec.function(ctx -> {
+						throw new RuntimeException("Something went wrong");
+					});
+				})
+				.withAlias(
+						aliasSpec -> {
+							aliasSpec.command("function", "command10");
+						}
+				)
+				.withErrorHandling(
+						errorHandlingSpec -> {
+							errorHandlingSpec.resolver((e) -> {
+								return CommandHandlingResult.of("Error handled: " + e.getMessage() + "\n");
+							});
+						}
+				)
+				.build();
 	}
 }


### PR DESCRIPTION
This PR is intended to fix issue https://github.com/spring-projects/spring-shell/issues/1127

I added all functions of `CommandRegistration.Builder` that have a `Consumer<?Spec>` to avoid chaining with the and function from specifications. This change improves code readability and indentation.

 This is my first contribution. Please let me know if there are any issues or if I need to make any adjustments.