### PR TITLE
Start of key value implementation

### DIFF
--- a/spring-shell-core/src/main/java/org/springframework/shell/command/parser/ParserConfig.java
+++ b/spring-shell-core/src/main/java/org/springframework/shell/command/parser/ParserConfig.java
@@ -62,8 +62,12 @@ public class ParserConfig {
 		/**
 		 * Defines if options are parsed using case-sensitivity, enabled on default.
 		 */
-		CASE_SENSITIVE_OPTIONS(true)
-		;
+		CASE_SENSITIVE_OPTIONS(true),
+
+
+		ALLOW_KEY_VALUE_SEPARATOR(true);
+
+
 
 		private final boolean defaultState;
 		private final long mask;


### PR DESCRIPTION
This is related to https://github.com/spring-projects/spring-shell/issues/979

I spent some time this afternoon with a very simple start: 

- added method to separate key=value pairs and to add key and value to the argument list.
- added some basic initial tests
- added configuration option to enable or disable the key value separation

I, however, have some additional questions:

**1. For array values: currently, that would look like:**
```
command option one two three
```
With a key-value separator: would that look like this?
 ```
command option==one two three
```
**2. empty values:**
The current (initial start) implementation would assign this as an empty value:
```
command option=
```
I can see where that could be unclear. 

**3. place of current key-value implementation:**
Currently, the key-value split method will look _at_ all arguments, including commands. The advantage is that it doesn't touch the Lexer.class tokenize method, but I would understand if _only_ options should be separated from their value using the key value separator. In that case, I will change this a bit.

I didn't want to push this initial _draft_ too far, before getting your feedback. Please let me know what you think.