### PR TITLE
Remove -SNAPSHOT from versions that are in tags

### DIFF
--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -3,6 +3,7 @@ antora:
     - require: '@springio/antora-extensions'
       root_component_name: 'shell'
     - require: '@springio/antora-extensions/asciinema-extension'
+    - require: './lib/antora/version-fix.js'
 site:
   title: Spring Shell
   url: https://docs.spring.io/spring-shell/reference

--- a/lib/antora/version-fix.js
+++ b/lib/antora/version-fix.js
@@ -1,0 +1,23 @@
+'use strict'
+
+module.exports.register = function () {
+    const logger = this.getLogger('version-fix')
+    this.once('contentAggregated', ({ contentAggregate }) => {
+        contentAggregate.forEach((componentVersionBucket) => {
+            logger.info(`tag=${componentVersionBucket.origins[0].tag} version=${componentVersionBucket.version}`)
+            // if it is a tag and a -SNAPSHOT release
+            if (componentVersionBucket.origins[0].tag && componentVersionBucket.prerelease === '-SNAPSHOT') {
+                // remove prerelease: -SNAPSHOT so it appears as a release
+                delete componentVersionBucket.prerelease
+                // If asciidoctor attribute name ends with -version, then remove -SNAPSHOT suffix (if present)
+                const attrs = componentVersionBucket.asciidoc.attributes
+                for (const [name, value] of Object.entries(attrs)) {
+                    if (name.endsWith('-version') && value.endsWith('-SNAPSHOT')) {
+                        attrs[name] = value.split('-SNAPSHOT').shift()
+                        logger.info(`Changing asciidoctor attr ${name} from ${value} to ${attrs[name]}`)
+                    }
+                }
+            }
+        })
+    })
+}


### PR DESCRIPTION
There were some errors in the releases which caused -SNAPSHOT to appear in released versions. This commit adds an antora extension that:

1) Removes -SNAPSHOT from the version of any tags
2) Removes -SNAPSHOT from asciidoctor attributes that end in -version