### PR TITLE
Use fetch-depth: 0

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -17,7 +17,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
         with:
-          fetch-depth: 5
+          # required for Antora to use the cloned repository to build
+          fetch-depth: 0
       - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:


### PR DESCRIPTION
This is required so that Antora can use the cloned repository for building the site.