### PR TITLE
Make interactive mode the default

### DIFF
--- a/spring-shell-autoconfigure/src/main/java/org/springframework/shell/boot/ShellRunnerAutoConfiguration.java
+++ b/spring-shell-autoconfigure/src/main/java/org/springframework/shell/boot/ShellRunnerAutoConfiguration.java
@@ -61,7 +61,7 @@ public class ShellRunnerAutoConfiguration {
 
 		@Bean
 		@ConditionalOnProperty(prefix = "spring.shell.interactive", value = "enabled", havingValue = "true",
-				matchIfMissing = false)
+				matchIfMissing = true)
 		public InteractiveShellRunner interactiveApplicationRunner(LineReader lineReader, PromptProvider promptProvider,
 				Shell shell, ShellContext shellContext) {
 			return new InteractiveShellRunner(lineReader, promptProvider, shell, shellContext);
@@ -69,7 +69,7 @@ public class ShellRunnerAutoConfiguration {
 
 		@Bean
 		@ConditionalOnProperty(prefix = "spring.shell.noninteractive", value = "enabled", havingValue = "true",
-				matchIfMissing = true)
+				matchIfMissing = false)
 		public NonInteractiveShellRunner nonInteractiveApplicationRunner(Shell shell, ShellContext shellContext,
 				ObjectProvider<NonInteractiveShellRunnerCustomizer> customizer) {
 			NonInteractiveShellRunner shellRunner = new NonInteractiveShellRunner(shell, shellContext);

--- a/spring-shell-autoconfigure/src/test/java/org/springframework/shell/boot/ShellRunnerAutoConfigurationTests.java
+++ b/spring-shell-autoconfigure/src/test/java/org/springframework/shell/boot/ShellRunnerAutoConfigurationTests.java
@@ -56,8 +56,8 @@ class ShellRunnerAutoConfigurationTests {
 	class Interactive {
 
 		@Test
-		void disabledByDefault() {
-			contextRunner.run(context -> assertThat(context).doesNotHaveBean(InteractiveShellRunner.class));
+		void enabledByDefault() {
+			contextRunner.run(context -> assertThat(context).hasSingleBean(InteractiveShellRunner.class));
 		}
 
 		@Test
@@ -72,18 +72,18 @@ class ShellRunnerAutoConfigurationTests {
 	class NonInteractive {
 
 		@Test
-		void enabledByDefault() {
-			contextRunner.run(context -> assertThat(context).hasSingleBean(NonInteractiveShellRunner.class));
-		}
-
-		@Test
 		void primaryCommandNotSet() {
-			contextRunner.run(context -> {
+			contextRunner.withPropertyValues("spring.shell.noninteractive.enabled:true").run(context -> {
 				assertThat(context).hasSingleBean(NonInteractiveShellRunner.class);
 				NonInteractiveShellRunner runner = context.getBean(NonInteractiveShellRunner.class);
 				String command = (String) ReflectionTestUtils.getField(runner, "primaryCommand");
 				assertThat(command).isNull();
 			});
+		}
+
+		@Test
+		void disabledByDefault() {
+			contextRunner.run(context -> assertThat(context).doesNotHaveBean(NonInteractiveShellRunner.class));
 		}
 
 		@Test
@@ -95,10 +95,12 @@ class ShellRunnerAutoConfigurationTests {
 		@Test
 		void canBeCustomized() {
 			NonInteractiveShellRunnerCustomizer customizer = mock(NonInteractiveShellRunnerCustomizer.class);
-			contextRunner.withBean(NonInteractiveShellRunnerCustomizer.class, () -> customizer).run(context -> {
-				NonInteractiveShellRunner runner = context.getBean(NonInteractiveShellRunner.class);
-				verify(customizer).customize(runner);
-			});
+			contextRunner.withPropertyValues("spring.shell.noninteractive.enabled:true")
+				.withBean(NonInteractiveShellRunnerCustomizer.class, () -> customizer)
+				.run(context -> {
+					NonInteractiveShellRunner runner = context.getBean(NonInteractiveShellRunner.class);
+					verify(customizer).customize(runner);
+				});
 		}
 
 	}


### PR DESCRIPTION
In the current commit, I'm changing the runner creation rules in the autoconfiguration module. Now, if the user doesn't specify a specific runner, we create a bean with `InteractiveShellRunner`.

I also rewrote the configuration test to accommodate our change.

Closes: gh-1186

**Note**: the build breaks not because of the current change, but because the previous commit in the repository breaks the build.