### PR TITLE
Remove commons-io dependency from PathSearch

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,6 @@
 		<spring-boot.version>4.0.0-SNAPSHOT</spring-boot.version>
 		<jline.version>3.30.6</jline.version>
 		<antlr-st4.version>4.3.4</antlr-st4.version>
-		<commons-io.version>2.20.0</commons-io.version>
 		<jakarta.validation-api.version>3.1.1</jakarta.validation-api.version>
 		<jspecify.version>1.0.0</jspecify.version>
 

--- a/spring-shell-core/pom.xml
+++ b/spring-shell-core/pom.xml
@@ -57,11 +57,6 @@
 			<version>${reactor.version}</version>
 		</dependency>
 		<dependency>
-			<groupId>commons-io</groupId>
-			<artifactId>commons-io</artifactId>
-			<version>${commons-io.version}</version>
-		</dependency>
-		<dependency>
 			<groupId>jakarta.validation</groupId>
 			<artifactId>jakarta.validation-api</artifactId>
 			<version>${jakarta.validation-api.version}</version>


### PR DESCRIPTION
In this commit, we replace the use of commons-io in PathSearch with api from jdk.

Closes: gh-1215