### PR TITLE
Fix HelpTests to work also on windows

### DIFF
--- a/spring-shell-core/src/test/java/org/springframework/shell/core/command/HelpTests.java
+++ b/spring-shell-core/src/test/java/org/springframework/shell/core/command/HelpTests.java
@@ -49,7 +49,7 @@ class HelpTests {
 					quit, exit: Exit the shell
 
 				""";
-		Assertions.assertEquals(expectedOutput, actualOutput);
+		Assertions.assertEquals(expectedOutput.replaceAll("\\R", "\n"), actualOutput.replaceAll("\\R", "\n"));
 	}
 
 	@Test
@@ -118,7 +118,7 @@ class HelpTests {
 
 
 				""";
-		Assertions.assertEquals(expectedOutput, actualOutput);
+		Assertions.assertEquals(expectedOutput.replaceAll("\\R", "\n"), actualOutput.replaceAll("\\R", "\n"));
 	}
 
 	@Test
@@ -190,7 +190,7 @@ class HelpTests {
 					hello, hey
 
 				""";
-		Assertions.assertEquals(expectedOutput, actualOutput);
+		Assertions.assertEquals(expectedOutput.replaceAll("\\R", "\n"), actualOutput.replaceAll("\\R", "\n"));
 	}
 
 }


### PR DESCRIPTION
There is a common issue with line separators between Windows and Linux systems. I’ve fixed the tests to ignore line separators.