### PR TITLE
fix: Configuration properties metadata are missing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -141,6 +141,16 @@
 							<artifactId>nullaway</artifactId>
 							<version>${nullaway.version}</version>
 						</path>
+						<path>
+							<groupId>org.springframework.boot</groupId>
+							<artifactId>spring-boot-autoconfigure-processor</artifactId>
+							<version>${spring-boot.version}</version>
+						</path>
+						<path>
+							<groupId>org.springframework.boot</groupId>
+							<artifactId>spring-boot-configuration-processor</artifactId>
+							<version>${spring-boot.version}</version>
+						</path>
 					</annotationProcessorPaths>
 				</configuration>
 			</plugin>

--- a/spring-shell-core-autoconfigure/pom.xml
+++ b/spring-shell-core-autoconfigure/pom.xml
@@ -47,6 +47,12 @@
 			<version>${spring-boot.version}</version>
 			<optional>true</optional>
 		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-autoconfigure-processor</artifactId>
+			<version>${spring-boot.version}</version>
+			<optional>true</optional>
+		</dependency>
 
         <!-- Optional dependencies -->
         <dependency>


### PR DESCRIPTION
The Maven compiler is now configured to allow running the Spring Boot Configuration Processor. Furthermore, a dependency to Spring Boot Autoconfigure Processor has been added to the autoconfigure module so that metadata is also generated for the autoconfiguration conditions.

Fixes gh-1267

References from the Spring Boot documentation: [here](https://docs.spring.io/spring-boot/specification/configuration-metadata/annotation-processor.html#page-title) and [here](https://docs.spring.io/spring-boot/reference/features/developing-auto-configuration.html#features.developing-auto-configuration.custom-starter.autoconfigure-module).