### PR TITLE
Sort command names in help output

### DIFF
--- a/spring-shell-core/src/main/java/org/springframework/shell/core/utils/Utils.java
+++ b/spring-shell-core/src/main/java/org/springframework/shell/core/utils/Utils.java
@@ -16,6 +16,7 @@
 
 package org.springframework.shell.core.utils;
 
+import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -89,6 +90,7 @@ public class Utils {
 			for (Command command : commands.stream()
 				.filter(c -> !c.isHidden())
 				.filter(c -> c.getGroup().equals(group))
+				.sorted(Comparator.comparing(Command::getName))
 				.toList()) {
 				stringBuilder.append("\t")
 					.append(command.getName())


### PR DESCRIPTION
Sort command names alphabetically in help output
This change ensures commands displayed by the help command are sorted alphabetically by command name

Fixes Issue 1279: https://github.com/spring-projects/spring-shell/issues/1279

Example of sorted output from help command:
<img width="1430" height="343" alt="Screenshot 2026-02-01 at 11 17 25 PM" src="https://github.com/user-attachments/assets/d0c962f1-639b-43b6-8a3e-63299a691edd" />
