### PR TITLE
Fix possible NPE in InteractiveShellRunner

### DIFF
--- a/spring-shell-core/src/main/java/org/springframework/shell/core/InteractiveShellRunner.java
+++ b/spring-shell-core/src/main/java/org/springframework/shell/core/InteractiveShellRunner.java
@@ -74,12 +74,13 @@ public abstract class InteractiveShellRunner implements ShellRunner {
 			String input;
 			try {
 				input = this.inputProvider.readInput();
-				if (input.isEmpty()) { // ignore empty lines
-					continue;
-				}
 				if (input == null || input.equalsIgnoreCase("quit") || input.equalsIgnoreCase("exit")) {
 					print("Exiting the shell");
 					break;
+				}
+				if (input.isEmpty()) {
+					// ignore empty lines
+					continue;
 				}
 			}
 			catch (Exception e) {


### PR DESCRIPTION
This is a small fix of potentional **NPE** in Interactive Shell Runner.

Consider following configuration:

```java
package org.springframework.shell.samples.helloworld.boot;

import org.jline.reader.LineReader;
import org.springframework.boot.autoconfigure.SpringBootApplication;
import org.springframework.boot.builder.SpringApplicationBuilder;
import org.springframework.context.annotation.Bean;
import org.springframework.context.annotation.Primary;
import org.springframework.shell.core.command.annotation.Command;
import org.springframework.shell.core.command.annotation.Option;
import org.springframework.shell.jline.JLineInputProvider;
import org.springframework.util.StringUtils;

@SpringBootApplication
public class SpringShellApplication {

	public static void main(String[] args) {
		new SpringApplicationBuilder(SpringShellApplication.class).properties("spring.shell.debug.enabled=true")
			.run(args);
	}

	@Command(name = "hello")
	public void sayHello(@Option String name) {
		System.out.println("Hello " + name + "!");
	}

	@Bean
	@Primary
	public JLineInputProvider myInputProvider(LineReader lineReader) {
		return new JLineInputProvider(lineReader) {
			@Override
			public String readInput() {
				String s = super.readInput();
				return StringUtils.hasLength(s) ? s : null;
			}
		};
	}

}
```

Just simple enter which produces `null` in `readInput` method will end in NPE.

<img width="1070" height="706" alt="obrazek" src="https://github.com/user-attachments/assets/fbba1df0-43cb-490e-8197-f6e76efe8562" />
