### PR TITLE
make ShellInputProvider Builder public to make it usable outside its own package

### DIFF
--- a/spring-shell-test/src/main/java/org/springframework/shell/test/ShellInputProvider.java
+++ b/spring-shell-test/src/main/java/org/springframework/shell/test/ShellInputProvider.java
@@ -40,11 +40,11 @@ public record ShellInputProvider(String command, Deque<String> inputs, Deque<Str
 	 * @param command the command for which the input provider is to be created
 	 * @return a new {@link Builder} instance initialized with the given command
 	 */
-	static Builder providerFor(String command) {
+	public static Builder providerFor(String command) {
 		return Builder.builder(command);
 	}
 
-	final static class Builder {
+	public static final class Builder {
 
 		private final String command;
 


### PR DESCRIPTION
The current way of defining ShellInputProvider makes it impossible to use it in another package than 'org.springframework.shell.test'.