### PR TITLE
Add missing space in error message between command and subcommands

### DIFF
--- a/spring-shell-core/src/main/java/org/springframework/shell/core/InteractiveShellRunner.java
+++ b/spring-shell-core/src/main/java/org/springframework/shell/core/InteractiveShellRunner.java
@@ -118,7 +118,7 @@ public abstract class InteractiveShellRunner implements ShellRunner {
 				while (cause != null && cause.getCause() != null) {
 					cause = cause.getCause();
 				}
-				String errorMessage = "Unable to run command " + parsedInput.commandName()
+				String errorMessage = "Unable to run command " + parsedInput.commandName() + " "
 						+ String.join(" ", parsedInput.subCommands());
 				if (cause != null && cause.getMessage() != null) {
 					errorMessage += ": " + cause.getMessage();

--- a/spring-shell-core/src/test/java/org/springframework/shell/core/InteractiveShellRunnerTests.java
+++ b/spring-shell-core/src/test/java/org/springframework/shell/core/InteractiveShellRunnerTests.java
@@ -1,0 +1,108 @@
+package org.springframework.shell.core;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Consumer;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.shell.core.command.Command;
+import org.springframework.shell.core.command.CommandContext;
+import org.springframework.shell.core.command.CommandParser;
+import org.springframework.shell.core.command.CommandRegistry;
+import org.springframework.shell.core.command.ParsedInput;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @author David Pilar
+ */
+class InteractiveShellRunnerTests {
+
+	@Test
+	void errorMessageHasSpaceBetweenCommandAndSubCommands() throws Exception {
+		// given: a command "foo bar" that throws when executed
+		Consumer<CommandContext> failingExecutor = ctx -> {
+			throw new RuntimeException("boom");
+		};
+		Command failingCommand = Command.builder().name("foo is bar").execute(failingExecutor);
+		CommandRegistry registry = new CommandRegistry();
+		registry.registerCommand(failingCommand);
+
+		ParsedInput parsedInput = ParsedInput.builder()
+			.commandName("foo")
+			.addSubCommand("is")
+			.addSubCommand("bar")
+			.build();
+		CommandParser parser = input -> parsedInput;
+
+		InputProvider inputProvider = new SingleLineInputProvider("foo is bar");
+		RecordingShellRunner runner = new RecordingShellRunner(inputProvider, parser, registry);
+
+		// when
+		runner.run(new String[0]);
+
+		// then
+		assertThat(runner.printed).anyMatch(line -> line.startsWith("Unable to run command foo is bar"));
+		assertThat(runner.printed).noneMatch(line -> line.contains("Unable to run command foois bar"));
+		assertThat(runner.printed).noneMatch(line -> line.contains("Unable to run command fooisbar"));
+		assertThat(runner.printed).noneMatch(line -> line.contains("Unable to run command foo isbar"));
+	}
+
+	private static class SingleLineInputProvider implements InputProvider {
+
+		private final String line;
+
+		private boolean consumed;
+
+		SingleLineInputProvider(String line) {
+			this.line = line;
+		}
+
+		@Override
+		public String readInput() {
+			if (consumed) {
+				return null;
+			}
+			consumed = true;
+			return line;
+		}
+
+	}
+
+	private static class RecordingShellRunner extends InteractiveShellRunner {
+
+		private final List<String> printed = new ArrayList<>();
+
+		private final PrintWriter writer = new PrintWriter(new StringWriter());
+
+		RecordingShellRunner(InputProvider inputProvider, CommandParser commandParser,
+				CommandRegistry commandRegistry) {
+			super(inputProvider, commandParser, commandRegistry);
+		}
+
+		@Override
+		public void print(String message) {
+			printed.add(message);
+		}
+
+		@Override
+		public void flush() {
+		}
+
+		@Override
+		public PrintWriter getWriter() {
+			return writer;
+		}
+
+		@Override
+		public InputReader getReader() {
+			return new InputReader() {
+			};
+		}
+
+	}
+
+}


### PR DESCRIPTION
Consider this configuration:

```java
package org.springframework.shell.samples.helloworld.boot;

import org.springframework.boot.SpringApplication;
import org.springframework.boot.autoconfigure.SpringBootApplication;
import org.springframework.shell.core.command.annotation.Command;
import org.springframework.shell.core.command.annotation.Option;

@SpringBootApplication
public class SpringShellApplication {

	public static void main(String[] args) {
		SpringApplication.run(SpringShellApplication.class, args);
	}

	@Command(name = "hello sub1 sub2", description = "Say hello to a given name", group = "Greetings",
			help = "A command that greets the user with 'Hello ${name}!'. Usage: hello [-n | --name]=<name>")
	public void sayHello(@Option(shortName = 'n', longName = "name", description = "the name of the person to greet",
			defaultValue = "World", required = true) String name) {
		System.out.println("Hello " + name + "!");
	}

}
```

There is missing space in error message when ommiting required option:

<img width="693" height="283" alt="obrazek" src="https://github.com/user-attachments/assets/16e42c3c-7acd-4bc2-af21-f629c5cf5e8d" />
