### PR TITLE
Fix missing argument information in output of help command

### DIFF
--- a/spring-shell-core/src/main/java/org/springframework/shell/core/command/AbstractCommand.java
+++ b/spring-shell-core/src/main/java/org/springframework/shell/core/command/AbstractCommand.java
@@ -15,21 +15,19 @@
  */
 package org.springframework.shell.core.command;
 
+import jakarta.validation.Path;
+import org.jspecify.annotations.Nullable;
+import org.springframework.shell.core.ParameterValidationException;
+import org.springframework.shell.core.command.availability.Availability;
+import org.springframework.shell.core.command.availability.AvailabilityProvider;
+import org.springframework.shell.core.command.completion.CompletionProvider;
+import org.springframework.shell.core.command.completion.DefaultCompletionProvider;
+import org.springframework.shell.core.command.exit.ExitStatusExceptionMapper;
+
 import java.io.PrintWriter;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
-
-import jakarta.validation.Path;
-
-import org.jspecify.annotations.Nullable;
-
-import org.springframework.shell.core.ParameterValidationException;
-import org.springframework.shell.core.command.availability.Availability;
-import org.springframework.shell.core.command.availability.AvailabilityProvider;
-import org.springframework.shell.core.command.completion.DefaultCompletionProvider;
-import org.springframework.shell.core.command.exit.ExitStatusExceptionMapper;
-import org.springframework.shell.core.command.completion.CompletionProvider;
 
 /**
  * Base class helping to build shell commands.
@@ -57,6 +55,8 @@ public abstract class AbstractCommand implements Command {
 	private CompletionProvider completionProvider = new DefaultCompletionProvider();
 
 	private List<CommandOption> options = new ArrayList<>();
+
+	private List<CommandArgument> arguments = new ArrayList<>();
 
 	private List<String> aliases = new ArrayList<>();
 
@@ -121,6 +121,15 @@ public abstract class AbstractCommand implements Command {
 
 	public void setOptions(List<CommandOption> options) {
 		this.options = options;
+	}
+
+	@Override
+	public List<CommandArgument> getArguments() {
+		return arguments;
+	}
+
+	public void setArguments(List<CommandArgument> arguments) {
+		this.arguments = arguments;
 	}
 
 	@Override

--- a/spring-shell-core/src/main/java/org/springframework/shell/core/command/Command.java
+++ b/spring-shell-core/src/main/java/org/springframework/shell/core/command/Command.java
@@ -15,22 +15,21 @@
  */
 package org.springframework.shell.core.command;
 
+import org.jspecify.annotations.Nullable;
+import org.springframework.shell.core.command.adapter.ConsumerCommandAdapter;
+import org.springframework.shell.core.command.adapter.FunctionCommandAdapter;
+import org.springframework.shell.core.command.availability.AvailabilityProvider;
+import org.springframework.shell.core.command.completion.CompletionProvider;
+import org.springframework.shell.core.command.completion.DefaultCompletionProvider;
+import org.springframework.shell.core.command.exit.ExitStatusExceptionMapper;
+import org.springframework.util.Assert;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.function.Consumer;
 import java.util.function.Function;
-
-import org.jspecify.annotations.Nullable;
-
-import org.springframework.shell.core.command.adapter.ConsumerCommandAdapter;
-import org.springframework.shell.core.command.adapter.FunctionCommandAdapter;
-import org.springframework.shell.core.command.availability.AvailabilityProvider;
-import org.springframework.shell.core.command.completion.DefaultCompletionProvider;
-import org.springframework.shell.core.command.exit.ExitStatusExceptionMapper;
-import org.springframework.shell.core.command.completion.CompletionProvider;
-import org.springframework.util.Assert;
 
 /**
  * @author Eric Bottard
@@ -97,6 +96,14 @@ public interface Command {
 	}
 
 	/**
+	 * Get the arguments of the command.
+	 * @return the arguments of the command
+	 */
+	default List<CommandArgument> getArguments() {
+		return Collections.emptyList();
+	}
+
+	/**
 	 * Get the availability provider of the command. Defaults to always available.
 	 * @return the availability provider of the command
 	 */
@@ -156,6 +163,8 @@ public interface Command {
 
 		private List<CommandOption> options = new ArrayList<>();
 
+		private List<CommandArgument> arguments = new ArrayList<>();
+
 		public Builder name(String name) {
 			this.name = name;
 			return this;
@@ -206,6 +215,11 @@ public interface Command {
 			return this;
 		}
 
+		public Builder arguments(CommandArgument... arguments) {
+			this.arguments = Arrays.asList(arguments);
+			return this;
+		}
+
 		public AbstractCommand execute(Consumer<CommandContext> commandExecutor) {
 			Assert.hasText(name, "'name' must be specified");
 
@@ -229,6 +243,7 @@ public interface Command {
 		private void init(AbstractCommand command) {
 			command.setAliases(aliases);
 			command.setOptions(options);
+			command.setArguments(arguments);
 			command.setAvailabilityProvider(availabilityProvider);
 			command.setCompletionProvider(completionProvider);
 			if (exitStatusExceptionMapper != null) {

--- a/spring-shell-core/src/main/java/org/springframework/shell/core/command/CommandArgument.java
+++ b/spring-shell-core/src/main/java/org/springframework/shell/core/command/CommandArgument.java
@@ -15,12 +15,62 @@
  */
 package org.springframework.shell.core.command;
 
+import org.jspecify.annotations.Nullable;
+
 /**
- * Record representing a runtime argument to a command.
+ * Record representing the definition as well as the runtime information about a command
+ * argument.
  *
  * @author Mahmoud Ben Hassine
  * @since 4.0.0
  */
-public record CommandArgument(int index, String value) {
+public record CommandArgument(int index, @Nullable String description, @Nullable String defaultValue,
+		@Nullable String value, Class<?> type) {
 
+	public static CommandArgument.Builder with() {
+		return new CommandArgument.Builder();
+	}
+
+	public static class Builder {
+
+		private int index = 0;
+
+		private @Nullable String description;
+
+		private @Nullable String defaultValue;
+
+		private @Nullable String value;
+
+		private Class<?> type = Object.class;
+
+		public CommandArgument.Builder index(int index) {
+			this.index = index;
+			return this;
+		}
+
+		public CommandArgument.Builder description(String description) {
+			this.description = description;
+			return this;
+		}
+
+		public CommandArgument.Builder defaultValue(String defaultValue) {
+			this.defaultValue = defaultValue;
+			return this;
+		}
+
+		public CommandArgument.Builder value(String value) {
+			this.value = value;
+			return this;
+		}
+
+		public CommandArgument.Builder type(Class<?> type) {
+			this.type = type;
+			return this;
+		}
+
+		public CommandArgument build() {
+			return new CommandArgument(index, description, defaultValue, value, type);
+		}
+
+	}
 }

--- a/spring-shell-core/src/main/java/org/springframework/shell/core/command/DefaultCommandParser.java
+++ b/spring-shell-core/src/main/java/org/springframework/shell/core/command/DefaultCommandParser.java
@@ -15,12 +15,12 @@
  */
 package org.springframework.shell.core.command;
 
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
-
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 
 /**
  * Default implementation of {@link CommandParser}. Supports options in the long form of
@@ -180,7 +180,7 @@ public class DefaultCommandParser implements CommandParser {
 	}
 
 	private CommandArgument parseArgument(int index, String word) {
-		return new CommandArgument(index, unquoteAndUnescapeQuoted(word));
+		return CommandArgument.with().index(index).value(unquoteAndUnescapeQuoted(word)).build();
 	}
 
 	private String unquoteAndUnescapeQuoted(String s) {

--- a/spring-shell-core/src/main/java/org/springframework/shell/core/command/Help.java
+++ b/spring-shell-core/src/main/java/org/springframework/shell/core/command/Help.java
@@ -15,10 +15,11 @@
  */
 package org.springframework.shell.core.command;
 
+import org.springframework.shell.core.utils.Utils;
+import org.springframework.util.StringUtils;
+
 import java.io.PrintWriter;
 import java.util.List;
-
-import org.springframework.shell.core.utils.Utils;
 
 /**
  * A command to display help about all available commands.
@@ -67,6 +68,7 @@ public class Help extends AbstractCommand {
 		appendName(command, helpMessageBuilder);
 		appendSynopsis(command, helpMessageBuilder);
 		appendOptions(command, helpMessageBuilder);
+		appendArguments(command, helpMessageBuilder);
 		appendAliases(command, helpMessageBuilder);
 		return helpMessageBuilder.toString();
 	}
@@ -82,9 +84,11 @@ public class Help extends AbstractCommand {
 
 	private void appendSynopsis(Command command, StringBuilder helpMessageBuilder) {
 		List<CommandOption> options = command.getOptions();
-		helpMessageBuilder.append("SYNOPSIS\n").append("\t").append(command.getName()).append(" ");
+		List<CommandArgument> arguments = command.getArguments();
+		helpMessageBuilder.append("SYNOPSIS\n").append("\t").append(command.getName());
 		if (!options.isEmpty()) {
 			for (CommandOption option : options) {
+				helpMessageBuilder.append(" ");
 				if (option.required()) {
 					helpMessageBuilder.append("[");
 				}
@@ -96,14 +100,24 @@ public class Help extends AbstractCommand {
 				}
 				helpMessageBuilder.append(" ").append(option.type().getSimpleName());
 				if (option.required()) {
-					helpMessageBuilder.append("] ");
-				}
-				else {
-					helpMessageBuilder.append(" ");
+					helpMessageBuilder.append("]");
 				}
 			}
 		}
-		helpMessageBuilder.append("--help\n\n");
+		if (!arguments.isEmpty()) {
+			for (CommandArgument argument : arguments) {
+				helpMessageBuilder.append(" ");
+				boolean hasDefaultValue = StringUtils.hasText(argument.defaultValue());
+				if (hasDefaultValue) {
+					helpMessageBuilder.append("[");
+				}
+				helpMessageBuilder.append("(").append(argument.type().getSimpleName()).append(")");
+				if (hasDefaultValue) {
+					helpMessageBuilder.append("]");
+				}
+			}
+		}
+		helpMessageBuilder.append(" ").append("--help\n\n");
 	}
 
 	private void appendOptions(Command command, StringBuilder helpMessageBuilder) {
@@ -137,6 +151,27 @@ public class Help extends AbstractCommand {
 		helpMessageBuilder.append("\t--help or -h").append("\n");
 		helpMessageBuilder.append("\thelp for ").append(command.getName()).append("\n");
 		helpMessageBuilder.append("\t").append("[Optional]").append("\n").append("\n");
+	}
+
+	private void appendArguments(Command command, StringBuilder helpMessageBuilder) {
+		List<CommandArgument> arguments = command.getArguments();
+		if (!arguments.isEmpty()) {
+			helpMessageBuilder.append("ARGUMENTS [Positional]\n");
+			int index = 0;
+			for (CommandArgument argument : arguments) {
+				helpMessageBuilder.append("\t");
+				helpMessageBuilder.append("[Index ").append(index++).append("]");
+				helpMessageBuilder.append(" ").append(argument.type().getSimpleName()).append("\n");
+				helpMessageBuilder.append("\t").append(argument.description()).append("\n");
+				String defaultValue = argument.defaultValue();
+				helpMessageBuilder.append("\t").append("[default = ");
+				Class<?> optionType = argument.type();
+				if (defaultValue == null && optionType.isPrimitive()) {
+					defaultValue = Utils.getDefaultValueForPrimitiveType(optionType).toString();
+				}
+				helpMessageBuilder.append(defaultValue).append("]\n\n");
+			}
+		}
 	}
 
 	private static void appendAliases(Command command, StringBuilder helpMessageBuilder) {

--- a/spring-shell-core/src/main/java/org/springframework/shell/core/command/annotation/support/CommandFactoryBean.java
+++ b/spring-shell-core/src/main/java/org/springframework/shell/core/command/annotation/support/CommandFactoryBean.java
@@ -15,18 +15,10 @@
  */
 package org.springframework.shell.core.command.annotation.support;
 
-import java.lang.reflect.Method;
-import java.lang.reflect.Parameter;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-
 import jakarta.validation.Validator;
-
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.jspecify.annotations.Nullable;
-
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.FactoryBean;
 import org.springframework.beans.factory.NoSuchBeanDefinitionException;
@@ -41,17 +33,25 @@ import org.springframework.core.convert.converter.GenericConverter;
 import org.springframework.core.convert.support.ConfigurableConversionService;
 import org.springframework.core.convert.support.DefaultConversionService;
 import org.springframework.shell.core.command.Command;
+import org.springframework.shell.core.command.CommandArgument;
 import org.springframework.shell.core.command.CommandCreationException;
 import org.springframework.shell.core.command.CommandOption;
 import org.springframework.shell.core.command.adapter.MethodInvokerCommandAdapter;
+import org.springframework.shell.core.command.annotation.Argument;
 import org.springframework.shell.core.command.annotation.CommandGroup;
 import org.springframework.shell.core.command.annotation.Option;
 import org.springframework.shell.core.command.availability.AvailabilityProvider;
+import org.springframework.shell.core.command.completion.CompletionProvider;
 import org.springframework.shell.core.command.completion.DefaultCompletionProvider;
 import org.springframework.shell.core.command.exit.ExitStatusExceptionMapper;
-import org.springframework.shell.core.command.completion.CompletionProvider;
 import org.springframework.shell.core.utils.Utils;
 import org.springframework.util.Assert;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.Parameter;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 
 /**
  * Factory bean to build instances of {@link Command}.
@@ -122,12 +122,14 @@ public class CommandFactoryBean implements ApplicationContextAware, FactoryBean<
 		Validator validator = getValidator();
 		CompletionProvider completionProvider = getCompletionProvider(completionProviderBeanName);
 		List<CommandOption> commandOptions = getCommandOptions();
+		List<CommandArgument> commandArguments = getCommandArguments();
 
 		// create command adapter
 		MethodInvokerCommandAdapter methodInvokerCommandAdapter = new MethodInvokerCommandAdapter(name, description,
 				group, help, hidden, this.method, targetObject, configurableConversionService, validator);
 		methodInvokerCommandAdapter.setAliases(Arrays.stream(aliases).toList());
 		methodInvokerCommandAdapter.setOptions(commandOptions);
+		methodInvokerCommandAdapter.setArguments(commandArguments);
 		methodInvokerCommandAdapter.setAvailabilityProvider(availabilityProviderBean);
 		methodInvokerCommandAdapter.setCompletionProvider(completionProvider);
 		if (exitStatusExceptionMapperBean != null) {
@@ -161,6 +163,26 @@ public class CommandFactoryBean implements ApplicationContextAware, FactoryBean<
 			}
 		}
 		return commandOptions;
+	}
+
+	private List<CommandArgument> getCommandArguments() {
+		List<CommandArgument> commandArguments = new ArrayList<>();
+		for (Parameter parameter : this.method.getParameters()) {
+			Argument argumentAnnotation = parameter.getAnnotation(Argument.class);
+			if (argumentAnnotation != null) {
+				int index = argumentAnnotation.index();
+				String description = argumentAnnotation.description();
+				String defaultValue = argumentAnnotation.defaultValue();
+				CommandArgument commandArgument = CommandArgument.with()
+					.index(index)
+					.description(description)
+					.defaultValue(defaultValue)
+					.type(parameter.getType())
+					.build();
+				commandArguments.add(commandArgument);
+			}
+		}
+		return commandArguments;
 	}
 
 	private CompletionProvider getCompletionProvider(String completionProviderBeanName) {

--- a/spring-shell-core/src/test/java/org/springframework/shell/core/command/HelpTests.java
+++ b/spring-shell-core/src/test/java/org/springframework/shell/core/command/HelpTests.java
@@ -15,13 +15,12 @@
  */
 package org.springframework.shell.core.command;
 
-import java.io.PrintWriter;
-import java.io.StringWriter;
-
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-
 import org.springframework.shell.core.InputReader;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
 
 class HelpTests {
 
@@ -80,7 +79,7 @@ class HelpTests {
 			});
 		ParsedInput parsedInput = ParsedInput.builder()
 			.commandName("hi")
-			.addArgument(new CommandArgument(0, "hi"))
+			.addArgument(CommandArgument.with().index(0).value("hi").build())
 			.build();
 		CommandRegistry commandRegistry = new CommandRegistry();
 		commandRegistry.registerCommand(command);
@@ -115,6 +114,87 @@ class HelpTests {
 					--help or -h
 					help for hi
 					[Optional]
+
+
+				""";
+		Assertions.assertEquals(expectedOutput.replaceAll("\\R", "\n"), actualOutput.replaceAll("\\R", "\n"));
+	}
+
+	@Test
+	void testHelpMessageForCommandWithArgs() throws Exception {
+		// given
+		CommandOption nameOption = CommandOption.with()
+			.shortName('n')
+			.longName("name")
+			.type(String.class)
+			.required(true)
+			.description("Name of the person to greet")
+			.build();
+		CommandOption timesOption = CommandOption.with()
+			.shortName('t')
+			.longName("times")
+			.type(int.class)
+			.required(false)
+			.defaultValue("1")
+			.description("Number of times to greet")
+			.build();
+		CommandArgument greetArgument = CommandArgument.with()
+			.index(0)
+			.type(String.class)
+			.defaultValue("hi")
+			.description("Custom text to greet")
+			.build();
+		Command command = Command.builder()
+			.name("hi")
+			.description("Say hi")
+			.group("Greetings")
+			.help("This command says hi to the user.")
+			.options(nameOption, timesOption)
+			.arguments(greetArgument)
+			.execute(commandContext -> {
+			});
+		ParsedInput parsedInput = ParsedInput.builder()
+			.commandName("hi")
+			.addArgument(CommandArgument.with().index(0).value("hi").build())
+			.build();
+		CommandRegistry commandRegistry = new CommandRegistry();
+		commandRegistry.registerCommand(command);
+		StringWriter stringWriter = new StringWriter();
+		PrintWriter outputWriter = new PrintWriter(stringWriter);
+		InputReader inputReader = new InputReader() {
+		};
+		CommandContext commandContext = new CommandContext(parsedInput, commandRegistry, outputWriter, inputReader);
+
+		// when
+		Help help = new Help();
+		help.execute(commandContext);
+
+		// then
+		String actualOutput = stringWriter.toString();
+		String expectedOutput = """
+				NAME
+					hi - Say hi
+
+				SYNOPSIS
+					hi [--name String] --times int [(String)] --help
+
+				OPTIONS
+					--name or -n String
+					Name of the person to greet
+					[Mandatory]
+
+					--times or -t int
+					Number of times to greet
+					[Optional, default = 1]
+
+					--help or -h
+					help for hi
+					[Optional]
+
+				ARGUMENTS [Positional]
+					[Index 0] String
+					Custom text to greet
+					[default = hi]
 
 
 				""";
@@ -157,7 +237,7 @@ class HelpTests {
 			});
 		ParsedInput parsedInput = ParsedInput.builder()
 			.commandName("hi")
-			.addArgument(new CommandArgument(0, "hi"))
+			.addArgument(CommandArgument.with().index(0).value("hi").build())
 			.build();
 		CommandRegistry commandRegistry = new CommandRegistry();
 		commandRegistry.registerCommand(command);
@@ -231,7 +311,7 @@ class HelpTests {
 			});
 		ParsedInput parsedInput = ParsedInput.builder()
 			.commandName("hello")
-			.addArgument(new CommandArgument(0, "hello"))
+			.addArgument(CommandArgument.with().index(0).value("hi").build())
 			.build();
 		CommandRegistry commandRegistry = new CommandRegistry();
 		commandRegistry.registerCommand(command);

--- a/spring-shell-core/src/test/java/org/springframework/shell/core/command/adapter/MethodInvokerCommandAdapterTests.java
+++ b/spring-shell-core/src/test/java/org/springframework/shell/core/command/adapter/MethodInvokerCommandAdapterTests.java
@@ -15,15 +15,10 @@
  */
 package org.springframework.shell.core.command.adapter;
 
-import java.io.PrintWriter;
-import java.io.StringWriter;
-import java.lang.reflect.Method;
-
 import jakarta.validation.Validation;
 import jakarta.validation.Validator;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
-
 import org.springframework.core.convert.support.DefaultConversionService;
 import org.springframework.shell.core.command.CommandArgument;
 import org.springframework.shell.core.command.CommandContext;
@@ -32,6 +27,10 @@ import org.springframework.shell.core.command.ExitStatus;
 import org.springframework.shell.core.command.annotation.Arguments;
 import org.springframework.shell.core.command.annotation.Command;
 import org.springframework.shell.core.command.annotation.Option;
+
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.lang.reflect.Method;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -106,10 +105,16 @@ class MethodInvokerCommandAdapterTests {
 			.thenReturn(CommandOption.with().longName("base").value("10").build());
 		StringWriter out = new StringWriter();
 		Mockito.when(ctx.parsedInput().arguments())
-			.thenReturn(java.util.List.of(new CommandArgument(0, "1"), new CommandArgument(1, "2"),
-					new CommandArgument(2, "3"), new CommandArgument(3, "4"), new CommandArgument(4, "5"),
-					new CommandArgument(5, "6"), new CommandArgument(6, "7"), new CommandArgument(7, "8"),
-					new CommandArgument(8, "9"), new CommandArgument(9, "10")));
+			.thenReturn(java.util.List.of(CommandArgument.with().index(0).value("1").build(),
+					CommandArgument.with().index(1).value("2").build(),
+					CommandArgument.with().index(2).value("3").build(),
+					CommandArgument.with().index(3).value("4").build(),
+					CommandArgument.with().index(4).value("5").build(),
+					CommandArgument.with().index(5).value("6").build(),
+					CommandArgument.with().index(6).value("7").build(),
+					CommandArgument.with().index(7).value("8").build(),
+					CommandArgument.with().index(8).value("9").build(),
+					CommandArgument.with().index(9).value("10").build()));
 		Mockito.when(ctx.outputWriter()).thenReturn(new PrintWriter(out));
 		MethodInvokerCommandAdapter adapter = new MethodInvokerCommandAdapter("name", "desc", "group", "help", false,
 				method, target, conversionService, validator);


### PR DESCRIPTION
https://github.com/spring-projects/spring-shell/issues/1344 :

* Add Argument information to Command registration for help display
* Update help display to include @Argument
* _Update help display to have optional options (sic) between square brackets_ **(reverted)**

However, there is still a point that bugs me: @Arguments... currently the somehow sit inbetween:
- @Option: the way Arguments are handled in [MethodInvokerCommandAdapter.java](https://github.com/spring-projects/spring-shell/blob/main/spring-shell-core/src/main/java/org/springframework/shell/core/command/adapter/MethodInvokerCommandAdapter.java) is closer to Option (iterate over parameter and check annotation on the fly)
- @Argument: as they don't have name per se, it is basically an Argument too

So I think this PR should be handled maybe as a basis, and need further discussion/improvement, as currently we would have Option and Argument in help but Arguments would be missing.

IMHO Arguments should be closer to Argument and have an index stored, and maybe see @Arguments as merely an extension of Argument (or reserve, Argument is an Arguments with arity of 1)